### PR TITLE
Reducing the EC2 clean up age window

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -41,7 +41,7 @@ periodics:
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_MAX_INSTANCE_AGE
-          value: "21600"
+          value: "10800"
         - name: INTEGRATION_TEST_INSTANCE_TAG
           value: "EKSA-E2E"
         command:


### PR DESCRIPTION
*Description of changes:*
Reduced the Age window for EC2 instances to 3 hours. Since we are running more tests we create more EC2 instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
