### PR TITLE
Update org name for kube-vip project

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-anywhere-build-tooling:
   - name: kube-vip-tooling-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|projects/plunder-app/kube-vip/.*"
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|projects/kube-vip/kube-vip/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
@@ -42,7 +42,7 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/plunder-app/kube-vip
+          make build -C projects/kube-vip/kube-vip
           &&
           touch /status/done
         livenessProbe:


### PR DESCRIPTION
Kube-vip updated their org from plunder-app to kube-vip, so we should do it for consistency.
/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
