### PR TITLE
Remove clone URI and SSH secret from jobs

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -23,13 +23,12 @@ periodics:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     extra_refs:
     - org: aws
       repo: eks-anywhere-build-tooling
       base_ref: main
-      clone_uri: git@github.com:aws/eks-anywhere-build-tooling.git
+    labels:
+      image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cluster-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     # We need to clone the MR CLI repo to build the controller binary and image. Since
     # it is a private repo, running git clone in the scripts would require mounting of
     # the SSH key secret. Instead of taking that route, we can have Prow clone it for us
@@ -36,7 +33,6 @@ presubmits:
     - org: aws
       repo: eks-anywhere
       base_ref: main
-      clone_uri: "git@github.com:aws/eks-anywhere.git"
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere-build-tooling.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     labels:
       image-build: "true"
     spec:

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere-prow-jobs.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -23,13 +23,10 @@ periodics:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     extra_refs:
     - org: aws
       repo: eks-anywhere
       base_ref: main
-      clone_uri: git@github.com:aws/eks-anywhere.git
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
@@ -19,14 +19,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -22,13 +22,10 @@ periodics:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     extra_refs:
     - org: aws
       repo: eks-anywhere
       base_ref: main
-      clone_uri: git@github.com:aws/eks-anywhere.git
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -20,14 +20,11 @@ presubmits:
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
     skip_report: false
-    clone_uri: git@github.com:aws/eks-anywhere.git
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -21,14 +21,11 @@ presubmits:
     cluster: "prow-presubmits-cluster"
     max_concurrency: 1
     skip_report: false
-    clone_uri: "git@github.com:aws/eks-anywhere.git"
     decoration_config:
       gcs_configuration:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
-      ssh_key_secrets:
-      - ssh-secret
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false


### PR DESCRIPTION
We don't clone URI and SSH secret fields in the jobs since the repos are public now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
