### PR TITLE
Run e2e presubmits only on main branch

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -19,6 +19,8 @@ presubmits:
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
     max_concurrency: 10
     cluster: "prow-presubmits-cluster"
+    branches:
+    - ^main$
     skip_report: false
     decoration_config:
       gcs_configuration:


### PR DESCRIPTION
Avoid running e2e presubmits on branches other than `main`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
