### PR TITLE
Don't run new project jobs on older release branch

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -36,8 +36,6 @@ presubmits:
         env:
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
-        - name: ARTIFACTS_READ_ROLE_ARN
-          value: "arn:aws:iam::857151390494:role/ArtifactsReadRole"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -19,6 +19,8 @@ presubmits:
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKSD_LATEST_RELEASES|projects/aws/eks-anywhere/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
+    skip_branches:
+    - release-0.1
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -33,8 +33,6 @@ presubmits:
         env:
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
-        - name: ARTIFACTS_READ_ROLE_ARN
-          value: "arn:aws:iam::857151390494:role/ArtifactsReadRole"
         command:
         - bash
         - -c
@@ -42,8 +40,8 @@ presubmits:
           make build -C projects/kubernetes-sigs/image-builder
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "16Gi"
+            cpu: "4"
           limits:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "16Gi"
+            cpu: "4"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -36,8 +36,6 @@ presubmits:
         env:
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
-        - name: ARTIFACTS_READ_ROLE_ARN
-          value: "arn:aws:iam::857151390494:role/ArtifactsReadRole"
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -19,6 +19,8 @@ presubmits:
       run_if_changed: "projects/replicatedhq/troubleshoot/.*"
       cluster: "prow-presubmits-cluster"
       max_concurrency: 10
+      skip_branches:
+      - release-0.1
       skip_report: false
       decoration_config:
         gcs_configuration:


### PR DESCRIPTION
The `release-0.1` branch on eks-anywhere-build-tooling doesn't build artifacts for eks-anywhere-diagnostic collector and the troubleshoot project, so we don't need to run these jobs for that branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
