### PR TITLE
Increase instance termination limit to 4.5 hours

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -38,7 +38,7 @@ periodics:
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_MAX_INSTANCE_AGE
-          value: "10800"
+          value: "16200"
         - name: INTEGRATION_TEST_INSTANCE_TAG
           value: "EKSA-E2E"
         command:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase instance termination limit to 4.5 hours so that there is enough time to debug e2e tests after the job fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
