### PR TITLE
Change make target for release tooling presubmit

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -35,7 +35,7 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C release
+          make dev-release -C release
         resources:
           requests:
             memory: "4Gi"

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -116,7 +116,7 @@ func ServiceAccountCheck(jc *JobConstants) presubmitCheck {
 
 func MakeTargetCheck(jc *JobConstants) presubmitCheck {
 	return presubmitCheck(func(presubmitConfig config.Presubmit, fileContentsString string) (bool, int, string) {
-		if strings.Contains(presubmitConfig.JobBase.Name, "e2e") || strings.Contains(presubmitConfig.JobBase.Name, "lint") || strings.Contains(presubmitConfig.JobBase.Name, "mocks") || presubmitConfig.JobBase.Name == "eks-anywhere-attribution-files-presubmit" || presubmitConfig.JobBase.Name == "eks-anywhere-cluster-controller-tooling-presubmit" {
+		if strings.Contains(presubmitConfig.JobBase.Name, "e2e") || strings.Contains(presubmitConfig.JobBase.Name, "lint") || strings.Contains(presubmitConfig.JobBase.Name, "mocks") || presubmitConfig.JobBase.Name == "eks-anywhere-attribution-files-presubmit" || presubmitConfig.JobBase.Name == "eks-anywhere-cluster-controller-tooling-presubmit" || presubmitConfig.JobBase.Name == "eks-anywhere-release-tooling-presubmit" {
 			return true, 0, ""
 		}
 		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?).*`).FindStringSubmatch(strings.Join(presubmitConfig.JobBase.Spec.Containers[0].Command, " "))


### PR DESCRIPTION
Changing make target to run dry-run dev release in presubmit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
