### PR TITLE
Add timestamps to logs in eks-a e2e presubmit job

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -46,7 +46,7 @@ presubmits:
         - bash
         - -c
         - >
-          make docker-e2e-test
+          'make docker-e2e-test | while IFS= read -r line; do printf "%s %s\n" "$(date "+%F %T")" "$line"; done'
         resources:
           requests:
             memory: "4Gi"


### PR DESCRIPTION
*Description of changes:*
There might be a cleaner/better way of doing this
This will be very useful to track what takes long in the job and fix regressions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
