### PR TITLE
Adding ARTIFACTS_BUCKET env variable to tink presubmit job

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:57d72a06719916cd715f07a716fa2d4b8a1e2235
+        env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c


### PR DESCRIPTION
*Description of changes:*
Tink build tooling does a fetch binaries. Hence ARTIFACTS_BUCKET env var is required to be set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
