### PR TITLE
Add more resources to CAPI build job

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -50,11 +50,11 @@ presubmits:
             - date +%s > /status/pending
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "8Gi"
+            cpu: "2048m"
           limits:
-            memory: "4Gi"
-            cpu: "1024m"
+            memory: "8Gi"
+            cpu: "2048m"
       - name: buildkitd
         image: moby/buildkit:v0.9.0-rootless
         command:


### PR DESCRIPTION
CAPI presubmit does 10x binary builds and 8x image builds, hence it's taking forever to build with 1 vCPU compute allocation. Bumping to 2 vCPU to see if it improves the job duration.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
