### PR TITLE
Add artifacts bucket env var to PBNJ presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -35,6 +35,9 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:cb4cb6c153c12a3db8974ad0bea26c9e4eecff97
+        env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c


### PR DESCRIPTION
The `grpc-health-probe` tarball will be fetched from this bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
