### PR TITLE
Adding Presubmit job for tinkerbell/hook

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -1,0 +1,77 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-anywhere-build-tooling:
+  - name: hook-tooling-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hook/.*"
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_branches:
+    - release-0.6
+    - release-0.7
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:cb4cb6c153c12a3db8974ad0bea26c9e4eecff97
+        command:
+        - bash
+        - -c
+        - >
+          build/lib/buildkit_check.sh
+          &&
+          make build -C projects/tinkerbell/hook
+          &&
+          touch /status/done
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - date +%s > /status/pending
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "16Gi" # Higher memory for kernel builds
+            cpu: "4"
+          limits:
+            memory: "16Gi"
+            cpu: "4"
+      - name: buildkitd
+        image: moby/buildkit:v0.9.0-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test $(($(date +%s) - 15)) -lt $(cat /status/pending)
+          periodSeconds: 15
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000


### PR DESCRIPTION
*Description of changes:*
Adding prow job for building `tinkerbell/hook`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
