### PR TITLE
Bump buildkit rootless image tag to v0.9.3

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.6.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.6.yaml
@@ -69,7 +69,7 @@ periodics:
           mountPath: /secrets/github-secrets
           readOnly: true
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -66,7 +66,7 @@ periodics:
           mountPath: /secrets/github-secrets
           readOnly: true
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "8Gi"
             cpu: "2048m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.9.0-rootless
+        image: moby/buildkit:v0.9.3-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
                 memory: "8Gi"
                 cpu: "1024m"
           - name: buildkitd
-            image: moby/buildkit:v0.9.0-rootless
+            image: moby/buildkit:v0.9.3-rootless
             command:
               - sh
             args:


### PR DESCRIPTION
Bumping to maintain parity with aws/eks-distro-prow-jobs#265.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
