### PR TITLE
Check if project path exists before building artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOLANG_VERSION?="1.16"
-export PULL_BASE_SHA?=$(shell git show -s --format=%H main)
+export PULL_BASE_SHA?=$(shell git show -s --format=%H upstream/main)
 export PULL_PULL_SHA?=$(shell git show -s --format=%H)
 
 BIN_DIR := bin
@@ -23,7 +23,7 @@ build: fmt vet ## Build linter
 	go build -o ./$(BIN_DIR)/prow-linter github.com/aws/eks-anywhere-prow-jobs/scripts/lint_prowjobs
 
 .PHONY: lint
-lint: ## Run linter
+lint: build ## Run linter
 	./$(BIN_DIR)/prow-linter
 
 .PHONY: help

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/boots
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/boots
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/aws/bottlerocket-bootstrap
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/aws/bottlerocket-bootstrap
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/jetstack/cert-manager
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/jetstack/cert-manager
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
@@ -41,9 +41,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/cloudflare/cfssl
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/cloudflare/cfssl
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -35,7 +35,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/cilium/cilium
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/cilium/cilium
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes/cloud-provider-vsphere
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes/cloud-provider-vsphere
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/apache/cloudstack-cloudmonkey
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/apache/cloudstack-cloudmonkey
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes-sigs/cluster-api
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/cluster-api
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes-sigs/cluster-api-provider-aws
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/cluster-api-provider-aws
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/aws/cluster-api-provider-cloudstack
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/aws/cluster-api-provider-cloudstack
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -41,9 +41,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/cluster-api-provider-tinkerbell
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/cluster-api-provider-tinkerbell
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes-sigs/cluster-api-provider-vsphere
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/cluster-api-provider-vsphere
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes-sigs/cri-tools
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/cri-tools
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/distribution/distribution
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/distribution/distribution
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/aws/eks-anywhere-build-tooling
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/aws/eks-anywhere-build-tooling
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/aws/eks-anywhere
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/aws/eks-anywhere
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/aws/eks-anywhere-test
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/aws/eks-anywhere-test
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/mrajashree/etcdadm-bootstrap-provider
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/mrajashree/etcdadm-bootstrap-provider
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/mrajashree/etcdadm-controller
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/mrajashree/etcdadm-controller
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes-sigs/etcdadm
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/etcdadm
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/fluxcd/flux2
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/fluxcd/flux2
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/vmware/govmomi
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/vmware/govmomi
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
@@ -37,7 +37,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/grpc-ecosystem/grpc-health-probe
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/grpc-ecosystem/grpc-health-probe
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-helm-presubmits.yaml
@@ -34,7 +34,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/goharbor/harbor-helm
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/goharbor/harbor-helm
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/goharbor/harbor
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/goharbor/harbor
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -41,9 +41,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/hegel
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/hegel
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/fluxcd/helm-controller
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/fluxcd/helm-controller
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -36,7 +36,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/helm/helm
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/helm/helm
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -43,12 +43,14 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/hook
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
         env:
         - name: IMAGE_REPO
           value: "localhost:5000"
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/hook
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/hub
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/hub
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -37,7 +37,10 @@ presubmits:
         - bash
         - -c
         - >
-          make build -C projects/kubernetes-sigs/image-builder
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/image-builder
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -42,9 +42,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes-sigs/kind
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/kind
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/brancz/kube-rbac-proxy
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/brancz/kube-rbac-proxy
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/plunder-app/kube-vip
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/plunder-app/kube-vip
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/fluxcd/kustomize-controller
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/fluxcd/kustomize-controller
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/rancher/local-path-provisioner
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/rancher/local-path-provisioner
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/fluxcd/notification-controller
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/fluxcd/notification-controller
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -44,9 +44,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/pbnj
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/pbnj
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/redis/redis
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/redis/redis
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -44,9 +44,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/fluxcd/source-controller
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/fluxcd/source-controller
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -44,9 +44,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/tinkerbell/tink
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/tink
         livenessProbe:
           exec:
             command:

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -36,7 +36,10 @@ presubmits:
               - bash
               - -c
               - >
-                make build -C projects/replicatedhq/troubleshoot
+                make build -C $PROJECT_PATH
+            env:
+            - name: PROJECT_PATH
+              value: projects/replicatedhq/troubleshoot
             resources:
               requests:
                 memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -39,9 +39,12 @@ presubmits:
         - >
           build/lib/buildkit_check.sh
           &&
-          make build -C projects/kubernetes-sigs/vsphere-csi-driver
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
           &&
           touch /status/done
+        env:
+        - name: PROJECT_PATH
+          value: projects/kubernetes-sigs/vsphere-csi-driver
         livenessProbe:
           exec:
             command:

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -147,7 +147,7 @@ func MakeTargetCheck(jc *JobConstants) presubmitCheck {
 		if strings.Contains(presubmitConfig.JobBase.Name, "e2e") || strings.Contains(presubmitConfig.JobBase.Name, "lint") || strings.Contains(presubmitConfig.JobBase.Name, "mocks") || presubmitConfig.JobBase.Name == "eks-anywhere-attribution-files-presubmit" || presubmitConfig.JobBase.Name == "eks-anywhere-cluster-controller-tooling-presubmit" || presubmitConfig.JobBase.Name == "eks-anywhere-release-tooling-presubmit" {
 			return true, 0, ""
 		}
-		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?).*`).FindStringSubmatch(strings.Join(presubmitConfig.JobBase.Spec.Containers[0].Command, " "))
+		jobMakeTargetMatches := regexp.MustCompile(`make (\w+[-\w]+?) -C .*`).FindStringSubmatch(strings.Join(presubmitConfig.JobBase.Spec.Containers[0].Command, " "))
 		jobMakeTarget := jobMakeTargetMatches[len(jobMakeTargetMatches)-1]
 		makeCommandLineNo := findLineNumber(fileContentsString, "make")
 		if jobMakeTarget != jc.DefaultMakeTarget {


### PR DESCRIPTION
Invoking a make target to check if project path exists as a precursor step to building the artifacts. This will allow the job to gracefully pass on other open PRs when adding a new project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
