### PR TITLE
Remove duplicate envvar field

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -33,9 +33,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
@@ -46,6 +43,8 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/aws/bottlerocket-bootstrap
         livenessProbe:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -33,9 +33,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
@@ -46,6 +43,8 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/aws/eks-anywhere-build-tooling
         livenessProbe:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -35,7 +35,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -30,15 +30,14 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
         - >
           if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/kubernetes-sigs/image-builder
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -33,9 +33,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
@@ -46,6 +43,8 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/kubernetes-sigs/kind
         livenessProbe:

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -35,9 +35,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
@@ -48,6 +45,8 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/tinkerbell/pbnj
         livenessProbe:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -33,11 +33,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: BINARY_PLATFORMS
-          value: "linux/amd64"
-        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-          value: "true"
         command:
         - bash
         - -c
@@ -48,6 +43,10 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: BINARY_PLATFORMS
+          value: "linux/amd64"
+        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+          value: "true"
         - name: PROJECT_PATH
           value: projects/fluxcd/source-controller
         livenessProbe:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -35,9 +35,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:dbaf51a45b1656b1c5ab6fea48de7bd725bf91dc.2
-        env:
-        - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         command:
         - bash
         - -c
@@ -48,6 +45,8 @@ presubmits:
           &&
           touch /status/done
         env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/tinkerbell/tink
         livenessProbe:


### PR DESCRIPTION
#100 added env var field for project path, but I failed to check for jobs having env vars already.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
