### PR TITLE
Revert "update integration test ami to use latest version"

### DIFF
--- a/config/job-constants.yaml
+++ b/config/job-constants.yaml
@@ -24,7 +24,7 @@ env:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-0dc229c75c29c4a38
+  value: ami-02952a544486f5777
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"
         - name: INTEGRATION_TEST_AL2_AMI_ID
-          value: "ami-0dc229c75c29c4a38"
+          value: "ami-02952a544486f5777"
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_INSTANCE_PROFILE


### PR DESCRIPTION
Reverts aws/eks-anywhere-prow-jobs#112

we want to use the original AMI, as the new one does not have the requisite kernel version for troubleshooting issues with Cilium and also seems to have other issues.