### PR TITLE
update to use new al2 5.x kernel ami

### DIFF
--- a/config/job-constants.yaml
+++ b/config/job-constants.yaml
@@ -24,7 +24,7 @@ env:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-02952a544486f5777
+  value: ami-0b8fba770ae226f0b
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"
         - name: INTEGRATION_TEST_AL2_AMI_ID
-          value: "ami-02952a544486f5777"
+          value: "ami-0b8fba770ae226f0b"
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_INSTANCE_PROFILE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To fix cilium 1.9.13+ we need to be using a newer kernel. This isnt an issue on ubuntu because it was already using a newer one.  This should only affect presubmits and capd tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
