### PR TITLE
Add pod label to specify builder-base image URI used for CI runtime

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -29,6 +29,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.8.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.8.yaml
@@ -28,6 +28,7 @@ periodics:
       repo: eks-anywhere-build-tooling
       base_ref: release-0.8
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -28,6 +28,7 @@ periodics:
       repo: eks-anywhere-build-tooling
       base_ref: main
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: postsubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-cert-manager-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-test-image-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
@@ -28,6 +28,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -29,6 +29,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
       local-registry: "true"
     spec:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -29,6 +29,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -25,6 +25,8 @@ presubmits:
         bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+    labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
           bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
           path_strategy: explicit
         s3_credentials_secret: s3-credentials
+      labels:
+        ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       spec:
         serviceaccountName: presubmits-build-account
         automountServiceAccountToken: false

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
+      ci-build-image: public.ecr.aws/eks-distro-build-tooling/builder-base:c78bfebd3c6a0a0307cd0982fedd9548268273df.2
       image-build: "true"
     spec:
       serviceaccountName: presubmits-build-account


### PR DESCRIPTION
Setting a `ci-build-image` label with the builder-base image as value to be later consumed for setting an env var `CI_BUILD_IMAGE` (aws/eks-distro-prow-jobs#301)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
