### PR TITLE
Adding rufio project presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -1,0 +1,67 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-anywhere-build-tooling:
+  - name: rufio-tooling-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/rufio/.*"
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_branches:
+    - release-0.6
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:85e2d32818f8d6bc4ed7c8079e90714f18b527d5.2
+        command:
+        - bash
+        - -c
+        - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          build/lib/buildkit_check.sh
+          &&
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: PROJECT_PATH
+          value: projects/tinkerbell/rufio
+        resources:
+          requests:
+            memory: "8Gi"
+            cpu: "1024m"
+          limits:
+            memory: "8Gi"
+            cpu: "1024m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.1-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000


### PR DESCRIPTION
*Description of changes:*
Adding presubmit job for tinkerbell/rufio build-tooling project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
