### PR TITLE
Remove skip_branches from all the prow jobs

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -19,9 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/boots/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
-    - release-0.7
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/cloudflare/cfssl/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/cluster-api-provider-tinkerbell/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/aws/eks-anywhere/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.1
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
@@ -19,9 +19,6 @@ presubmits:
     run_if_changed: "^build/lib/.*|Common.mk|projects/grpc-ecosystem/grpc-health-probe/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
-    - release-0.7
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hegel/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "^build/lib/.*|Common.mk|projects/helm/helm/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -19,9 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hook/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
-    - release-0.7
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -19,9 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hub/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
-    - release-0.7
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/pbnj/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/rufio/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/tink/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
-    skip_branches:
-    - release-0.6
     skip_report: false
     decoration_config:
       gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -19,8 +19,6 @@ presubmits:
       run_if_changed: "^build/lib/.*|Common.mk|projects/replicatedhq/troubleshoot/.*"
       cluster: "prow-presubmits-cluster"
       max_concurrency: 10
-      skip_branches:
-      - release-0.1
       skip_report: false
       decoration_config:
         gcs_configuration:


### PR DESCRIPTION
*Description of changes:*
Comes from the discussion in this thread https://github.com/aws/eks-anywhere-prow-jobs/pull/156#discussion_r888019217
`skip_branches` is no longer needed because the job checks if the project path exists before running the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
