### PR TITLE
Moving capc from aws to kubernetes-sigs github org

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
   aws/eks-anywhere-build-tooling:
   - name: cluster-api-provider-cloudstack-tooling-presubmit
     always_run: false
-    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/aws/cluster-api-provider-cloudstack/.*"
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/cluster-api-provider-cloudstack/.*"
     cluster: "prow-presubmits-cluster"
     max_concurrency: 10
     skip_report: false
@@ -44,7 +44,7 @@ presubmits:
           if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
-          value: projects/aws/cluster-api-provider-cloudstack
+          value: projects/kubernetes-sigs/cluster-api-provider-cloudstack
         resources:
           requests:
             memory: "16Gi"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Renaming repo from aws -> kubernetes-sigs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
