### PR TITLE
Max out CPU resources for EKS-A CLI presubmits

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -38,8 +38,8 @@ presubmits:
           make build
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2048m"
+            memory: "16Gi"
+            cpu: "4"
           limits:
-            memory: "8Gi"
-            cpu: "2048m"
+            memory: "16Gi"
+            cpu: "4"


### PR DESCRIPTION
/woof


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
