### PR TITLE
Update builder-base image tag in Prow jobs

### DIFF
--- a/BUILDER_BASE_TAG_FILE
+++ b/BUILDER_BASE_TAG_FILE
@@ -1,1 +1,1 @@
-fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.10.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.10.yaml
@@ -34,7 +34,7 @@ periodics:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         env:
         - name: PULL_BASE_REF
           value: release-0.10

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -34,7 +34,7 @@ periodics:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cfssl-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -33,7 +33,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/pbnj-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
         serviceaccountName: presubmits-build-account
         automountServiceAccountToken: false
         containers:
-          - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+          - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
             command:
               - bash
               - -c

--- a/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
         automountServiceAccountToken: false
         containers:
         - name: build-container
-          image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+          image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
           command:
           - bash
           - -c

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
@@ -36,7 +36,7 @@ postsubmits:
         automountServiceAccountToken: false
         containers:
           - name: build-container
-            image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+            image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
             command:
               - bash
               - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
         automountServiceAccountToken: false
         containers:
           - name: build-container
-            image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+            image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
             command:
               - bash
               - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestCleanUpBuildRole"

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         env:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"

--- a/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:fded92fccf5422382c8aecd4bbbf1be3670e0aca.2
+      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:576b89eaf1edd40780fcbbf671ff6e66ca4163d8.2
         command:
         - bash
         - -c


### PR DESCRIPTION
This PR updates the base image tag in the Tag file and in all the prowjobs with the tag of the most recently built builder-base image. The Codebuild projects will also be updated to use this same tag by a periodic Lambda.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
