### PR TITLE
Prune buildkit cache after every build of Bottlerocket bootstrap image

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -47,6 +47,8 @@ presubmits:
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PROJECT_PATH
           value: projects/aws/bottlerocket-bootstrap
+        - name: PRUNE_BUILDCTL
+          value: "true"
         resources:
           requests:
             memory: "16Gi"


### PR DESCRIPTION
The Bottlerocket bootstrap is built for multiple Kubernetes versions so the buildkit cache needs to be pruned after every build to save space on disk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
