### PR TITLE
Add container name to presubmits podspec

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/grpc-health-probe-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -31,7 +31,8 @@ presubmits:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:
-      - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -14,49 +14,50 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-    - name: troubleshoot-tooling-presubmit
-      always_run: false
-      run_if_changed: "^build/lib/.*|Common.mk|projects/replicatedhq/troubleshoot/.*"
-      cluster: "prow-presubmits-cluster"
-      max_concurrency: 10
-      skip_report: false
-      decoration_config:
-        gcs_configuration:
-          bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
-          path_strategy: explicit
-        s3_credentials_secret: s3-credentials
-      labels:
-        image-build: "true"
-      spec:
-        serviceaccountName: presubmits-build-account
-        automountServiceAccountToken: false
-        containers:
-        - image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
-          command:
-          - bash
-          - -c
-          - >
-            trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
-            &&
-            build/lib/buildkit_check.sh
-            &&
-            make build -C $PROJECT_PATH
-          env:
-          - name: PROJECT_PATH
-            value: projects/replicatedhq/troubleshoot
-          resources:
-            requests:
-              memory: "16Gi"
-              cpu: "4"
-            limits:
-              memory: "16Gi"
-              cpu: "4"
-        - name: buildkitd
-          image: moby/buildkit:v0.10.1-rootless
-          command:
-          - sh
-          args:
-          - /script/entrypoint.sh
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+  - name: troubleshoot-tooling-presubmit
+    always_run: false
+    run_if_changed: "^build/lib/.*|Common.mk|projects/replicatedhq/troubleshoot/.*"
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+        command:
+        - bash
+        - -c
+        - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          build/lib/buildkit_check.sh
+          &&
+          make build -C $PROJECT_PATH
+        env:
+        - name: PROJECT_PATH
+          value: projects/replicatedhq/troubleshoot
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
+          limits:
+            memory: "16Gi"
+            cpu: "4"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.1-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000


### PR DESCRIPTION
All containers must have names when defining multiple containers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
