### PR TITLE
Update CAPX build-tooling presubmit job

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:91e37cccb386f038535ace5d9df762ec1750fc7b.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:latest
         command:
         - bash
         - -c


### PR DESCRIPTION
Use latest image for builder-base for building Nutanix Cluster API provider in eks-anywhere-build-tooling.
