### PR TITLE
Update prometheus job name

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: prometheus-tooling-presubmit
+  - name: prometheus-prometheus-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/prometheus/.*"
     cluster: "prow-presubmits-cluster"


### PR DESCRIPTION
eks-distro-build-tooling has another prometheus project with the same name, see [here](https://github.com/aws/eks-distro-prow-jobs/blob/main/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml#L21). So we will re-name this project to avoid conflict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
