### PR TITLE
Update daily periodic timing to night and add nodeSelector

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.12.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.12.yaml
@@ -14,7 +14,7 @@
 
 periodics:
   - name: build-tooling-attribution-files-periodic-release-0-12
-    # Runs every weekday (M-F) at 2PM PST
+    # Runs every weekday (M-F) at 1AM PDT
     cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.12.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics-release-0.12.yaml
@@ -15,7 +15,7 @@
 periodics:
   - name: build-tooling-attribution-files-periodic-release-0-12
     # Runs every weekday (M-F) at 2PM PST
-    cron: "0 21 * * 1-5"
+    cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
     decoration_config:
       timeout: 4h
@@ -30,6 +30,8 @@ periodics:
     labels:
       image-build: "true"
     spec:
+      nodeSelector:
+        arch: "AMD64"
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       containers:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -14,7 +14,7 @@
 
 periodics:
   - name: build-tooling-attribution-files-periodic
-    # Runs every weekday (M-F) at 2PM PST
+    # Runs every weekday (M-F) at 1AM PDT 
     cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/build-tooling-attribution-files-periodics.yaml
@@ -15,7 +15,7 @@
 periodics:
   - name: build-tooling-attribution-files-periodic
     # Runs every weekday (M-F) at 2PM PST
-    cron: "0 21 * * 1-5"
+    cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
     decoration_config:
       timeout: 4h
@@ -30,6 +30,8 @@ periodics:
     labels:
       image-build: "true"
     spec:
+      nodeSelector:
+        arch: "AMD64"
       serviceaccountName: postsubmits-build-account
       automountServiceAccountToken: false
       containers:

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -15,7 +15,7 @@
 periodics:
   - name: eks-anywhere-attribution-files-periodic
     # Runs every weekday (M-F) at 2PM PST
-    cron: "0 21 * * 1-5"
+    cron: "0 8 * * 1-5"
     cluster: "prow-presubmits-cluster"
     decoration_config:
       timeout: 3h
@@ -28,6 +28,8 @@ periodics:
       repo: eks-anywhere
       base_ref: main
     spec:
+      nodeSelector:
+        arch: "AMD64"
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -14,7 +14,7 @@
 
 periodics:
   - name: eks-anywhere-attribution-files-periodic
-    # Runs every weekday (M-F) at 2PM PST
+    # Runs every weekday (M-F) at 1AM PDT
     cron: "0 8 * * 1-5"
     cluster: "prow-presubmits-cluster"
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -27,6 +27,8 @@ periodics:
       repo: eks-anywhere
       base_ref: main
     spec:
+      nodeSelector:
+        arch: "AMD64"
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates daily periodics to run in the middle of hte night (1am PT) instead of during hte day. Also, adds the new `nodeSelector` to the spec

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
