### PR TITLE
Renames the attribution jobs to be more clear

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.12.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.12.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 periodics:
-  - name: build-tooling-attribution-files-periodic-release-0-12
+  - name: eks-anywhere-attribution-periodic-release-0-12
     # Runs every weekday (M-F) at 1AM PDT
     cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
@@ -52,10 +52,7 @@ periodics:
         resources:
           requests:
             memory: "16Gi"
-            cpu: "4"
-          limits:
-            memory: "16Gi"
-            cpu: "4"
+            cpu: "5"
         volumeMounts:
         - name: ssh-auth
           mountPath: /secrets/ssh-secrets

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 periodics:
-  - name: build-tooling-attribution-files-periodic
+  - name: eks-anywhere-attribution-periodic
     # Runs every weekday (M-F) at 1AM PDT 
     cron: "0 8 * * 1-5"
     cluster: "prow-postsubmits-cluster"
@@ -49,10 +49,7 @@ periodics:
         resources:
           requests:
             memory: "16Gi"
-            cpu: "4"
-          limits:
-            memory: "16Gi"
-            cpu: "4"
+            cpu: "5"
         volumeMounts:
         - name: ssh-auth
           mountPath: /secrets/ssh-secrets

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -28,8 +28,6 @@ periodics:
       repo: eks-anywhere
       base_ref: main
     spec:
-      nodeSelector:
-        arch: "AMD64"
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -27,8 +27,6 @@ periodics:
       repo: eks-anywhere
       base_ref: main
     spec:
-      nodeSelector:
-        arch: "AMD64"
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
       containers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I am renaming these jobs to make them easier to find in the UI and identify against the eks-distro one, I am also changing the eks-distro one as well.

Also bump the CPU request to ensure two of these do not run on the same node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
