### PR TITLE
Adds source-controller arm presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
@@ -1,0 +1,69 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-anywhere-build-tooling:
+  - name: source-controller-tooling-presubmit-arm64
+    always_run: false
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GIT_TAG_FILE|^build/lib/.*|Common.mk|projects/fluxcd/source-controller/.*"
+    cluster: "prow-postsubmits-cluster"
+    max_concurrency: 10
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: postsubmits-build-account
+      automountServiceAccountToken: false
+      nodeSelector:
+        arch: ARM64
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2cce7b1d849a8d61f7be5b936e6f47640f534b30.2
+        command:
+        - bash
+        - -c
+        - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          build/lib/buildkit_check.sh
+          &&
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: BINARY_PLATFORMS
+          value: "linux/arm64"
+        - name: PROJECT_PATH
+          value: projects/fluxcd/source-controller
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        resources:
+          requests:
+            memory: "8Gi"
+            cpu: "1024m"
+          limits:
+            memory: "8Gi"
+            cpu: "1024m"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.5-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -123,6 +123,10 @@ func BucketCheck(jc *JobConstants) presubmitCheck {
 
 func ClusterCheck(jc *JobConstants) presubmitCheck {
 	return presubmitCheck(func(presubmitConfig config.Presubmit, fileContentsString string) (bool, int, string) {
+		if strings.Contains(presubmitConfig.JobBase.Name, "arm64") {
+			return true, 0, ""
+		}
+
 		if presubmitConfig.JobBase.Cluster != jc.Cluster {
 			return false, findLineNumber(fileContentsString, "cluster:"), fmt.Sprintf(`Incorrect cluster configuration, please configure cluster as => cluster: "%s"`, jc.Cluster)
 		}
@@ -133,6 +137,9 @@ func ClusterCheck(jc *JobConstants) presubmitCheck {
 func ServiceAccountCheck(jc *JobConstants) presubmitCheck {
 	return presubmitCheck(func(presubmitConfig config.Presubmit, fileContentsString string) (bool, int, string) {
 		if strings.Contains(presubmitConfig.JobBase.Name, "e2e") {
+			return true, 0, ""
+		}
+		if strings.Contains(presubmitConfig.JobBase.Name, "arm64") {
 			return true, 0, ""
 		}
 		if presubmitConfig.JobBase.Spec.ServiceAccountName != jc.ServiceAccountName {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Running this presubmit on the postsubmit cluster so we can actually validate the arm binary builds, which require cgo, in presubmit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
