### PR TITLE
Run brew update postsubmit exclusively on AMD64 nodes

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
@@ -32,6 +32,8 @@ postsubmits:
           path_strategy: explicit
         s3_credentials_secret: s3-credentials
       spec:
+        nodeSelector:
+          arch: "AMD64"
         serviceaccountName: postsubmits-build-account
         automountServiceAccountToken: false
         containers:


### PR DESCRIPTION
This ensures the job does not run on ARM64 nodes, otherwise it pulls the ARM64 builder-base, and in the brew update script we download the AMD64 yq binary
```
YQ_LATEST_RELEASE_URL="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"

wget -qO /usr/local/bin/yq $YQ_LATEST_RELEASE_URL
chmod a+x /usr/local/bin/yq`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
