### PR TITLE
add builtctl prune to cloud provider job

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -52,6 +52,8 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: PRUNE_BUILDCTL
+          value: "true"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -8,3 +8,6 @@ resources:
   requests:
     memory: 16Gi
     cpu: 4
+envVars:
+  - name: PRUNE_BUILDCTL
+    value: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We're running into [space issues on this pre-submit](https://github.com/aws/eks-anywhere-build-tooling/pull/1814); adding a buildctl prune to free up some megs of space

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
