### PR TITLE
Add new env var to clean cache during presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -52,6 +52,8 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/emissary-ingress/emissary"
+        - name: PRUNE_BUILDCTL
+          value: "true"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -8,3 +8,6 @@ resources:
   requests:
     memory: 16Gi
     cpu: 4
+envVars:
+  - name: PRUNE_BUILDCTL
+    value: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cleaning the cache is now handled in Common.mk by default if this value is set for all jobs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
