### PR TITLE
Configure all jobs to error out on eviction

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-21-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-21-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-22-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-22-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-23-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-23-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-24-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-24-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aws/image-builder/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-observability/aws-otel-collector/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/boots/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws/bottlerocket-bootstrap/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/cert-manager/cert-manager/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "projects/cilium/cilium/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-vsphere/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/apache/cloudstack-cloudmonkey/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_DOCKER_CLIENT_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes-sigs/cluster-api/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aws/cluster-api-provider-aws-snow/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/cluster-api-provider-cloudstack/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/nutanix-cloud-native/cluster-api-provider-nutanix/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/cluster-api-provider-tinkerbell/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/cluster-api-provider-vsphere/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes-sigs/cri-tools/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/distribution/distribution/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/aws/eks-a-admin-image/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.14.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.14.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-attribution-periodic-release-0-14
   cron: "0 8 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 4h
     gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-attribution-periodic
   cron: "0 8 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 4h
     gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-checksum-periodics-release-0.14.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-checksum-periodics-release-0.14.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-checksum-periodic-release-0-14
   cron: "0 8 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 4h
     gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-checksum-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-checksum-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-checksum-periodic
   cron: "0 8 * * 1-5"
   cluster: "prow-postsubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 4h
     gcs_configuration:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_DOCKER_CLIENT_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/aws/eks-anywhere-build-tooling/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/aws/eks-anywhere/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws/eks-anywhere-packages/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_PYTHON_TAG_FILE|^build/lib/.*|Common.mk|projects/emissary-ingress/emissary/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/envoyproxy/envoy/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws/etcdadm-bootstrap-provider/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws/etcdadm-controller/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes-sigs/etcdadm/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/fluxcd/flux2/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/vmware/govmomi/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/goharbor/harbor/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aquasecurity/harbor-scanner-trivy/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hegel/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-containers/hello-eks-anywhere/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/fluxcd/helm-controller/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/helm/helm/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hook/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/hub/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes-sigs/image-builder/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_KIND_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes-sigs/kind/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/brancz/kube-rbac-proxy/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kube-vip/kube-vip/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GIT_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/fluxcd/kustomize-controller/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/torvalds/linux/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/rancher/local-path-provisioner/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/metallb/metallb/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes-sigs/metrics-server/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/fluxcd/notification-controller/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/node_exporter/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/prometheus/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/redis/redis/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/rufio/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GIT_TAG_FILE|^build/lib/.*|Common.mk|projects/fluxcd/source-controller/.*"
     cluster: "prow-postsubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GIT_TAG_FILE|^build/lib/.*|Common.mk|projects/fluxcd/source-controller/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/tinkerbell/tink/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/tinkerbell/tinkerbell-chart/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aquasecurity/trivy/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/replicatedhq/troubleshoot/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|Makefile|EKSD_LATEST_RELEASES|GIT_TAG|staging-build.yml|.*buildspec.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_CSI_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes-sigs/vsphere-csi-driver/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^generatebundlefile/"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: ".*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|jobs/aws/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-file-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-attribution-files-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-attribution-files-periodic
   cron: "0 8 * * 1-5"
   cluster: "prow-presubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 3h
     gcs_configuration:

--- a/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-generate-golden-files-periodic
   cron: "8 * * * 1-5"
   cluster: "prow-presubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     timeout: 30m
     gcs_configuration:

--- a/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
@@ -26,6 +26,7 @@ postsubmits:
     branches:
     - ^release-.*$
     cluster: "prow-postsubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     extra_refs:

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "^config/.*|^controllers/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "docs/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -22,6 +22,7 @@ periodics:
 - name: eks-anywhere-e2e-cleanup-periodic
   cron: "0 */1 * * *"
   cluster: "prow-presubmits-cluster"
+  error_on_eviction: true
   decoration_config:
     gcs_configuration:
       bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
     branches:
     - ^main$
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-mocks-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 10
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
     always_run: false
     run_if_changed: "release/.*"
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 1
     skip_report: false
     decoration_config:

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
     branches:
     - ^main$
     cluster: "prow-presubmits-cluster"
+    error_on_eviction: true
     max_concurrency: 1
     skip_report: false
     decoration_config:

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -19,6 +19,7 @@ periodics:
 - name: {{ .prowjobName }}
   cron: "{{ .cronExpression }}"
   cluster: "{{ .cluster }}"
+  error_on_eviction: true
   decoration_config:
     {{- if .timeout }}
     timeout: {{ .timeout }}

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -31,6 +31,7 @@ postsubmits:
     {{- end }}
     {{- end }}
     cluster: "{{ .cluster }}"
+    error_on_eviction: true
     max_concurrency: {{or .maxConcurrency 10 }}
     skip_report: false
     {{- if .extraRefs }}

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -27,6 +27,7 @@ presubmits:
     {{- end }}
     {{- end }}
     cluster: "{{ .cluster }}"
+    error_on_eviction: true
     max_concurrency: {{or .maxConcurrency 10 }}
     skip_report: false
     {{- if .extraRefs }}


### PR DESCRIPTION
We don't want Prowjobs to keep restarting every time the job Pods get evicted from the node due to reasons like lack of disk space, exceeding resource limits etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
