### PR TITLE
Adds readonly github token to all presubmits

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-21-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-21-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-22-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-22-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-23-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-23-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-23"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-24-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-24-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-24"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-25"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-26"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws-observability/aws-otel-collector"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/boots"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/bottlerocket-bootstrap"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/cert-manager/cert-manager"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/cilium/cilium"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-presubmit.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-21-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-21-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-22-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-22-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-23-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-23-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-23"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-24-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-24-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-24"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-25-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-25"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-26-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-26"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/apache/cloudstack-cloudmonkey"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/cluster-api"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/cluster-api-provider-aws-snow"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/cluster-api-provider-cloudstack"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/nutanix-cloud-native/cluster-api-provider-nutanix"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/cluster-api-provider-tinkerbell"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/cluster-api-provider-vsphere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/cri-tools"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/distribution/distribution"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/eks-a-admin-image"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/eks-anywhere-build-tooling"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/eks-anywhere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/eks-anywhere-packages"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/emissary-ingress/emissary"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: PRUNE_BUILDCTL
           value: "true"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/envoyproxy/envoy"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/etcdadm-bootstrap-provider"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/etcdadm-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/etcdadm"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/flux2"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/vmware/govmomi"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/goharbor/harbor"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PRUNE_BUILDCTL

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aquasecurity/harbor-scanner-trivy"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/hegel"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws-containers/hello-eks-anywhere"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/helm-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/helm/helm"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -56,6 +56,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/hook"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: IMAGE_REPO
           value: "localhost:5000"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/hub"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-21-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-21-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-21"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-22-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-22-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-22"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-23-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-23-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-23"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-24-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-24-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-24"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-25"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: RELEASE_BRANCH
           value: "1-26"
         - name: ARTIFACTS_BUCKET

--- a/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/kind"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/brancz/kube-rbac-proxy"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kube-vip/kube-vip"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/kustomize-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/torvalds/linux"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/rancher/local-path-provisioner"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/metallb/metallb"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/metrics-server"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/notification-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/prometheus/node_exporter"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/prometheus/prometheus"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/redis/redis"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aws/rolesanywhere-credential-helper"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/rufio"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
@@ -55,6 +55,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/source-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: BINARY_PLATFORMS
           value: "linux/arm64"
         - name: IMAGE_PLATFORMS

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/fluxcd/source-controller"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: BINARY_PLATFORMS
           value: "linux/amd64"
         - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/tink"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/tinkerbell/tinkerbell-chart"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/aquasecurity/trivy"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/replicatedhq/troubleshoot"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/vsphere-csi-driver-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/vsphere-csi-driver"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -52,6 +52,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "templater"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -53,6 +53,11 @@ presubmits:
           &&
           set -o pipefail && make docker-e2e-test | while IFS= read -r line; do printf "%s %s\n" "$(date --rfc-3339=seconds)" "$line"; done
         env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"
         - name: INTEGRATION_TEST_AL2_AMI_ID

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -50,6 +50,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "release"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
@@ -52,6 +52,11 @@ presubmits:
         env:
         - name: PROJECT_PATH
           value: "release"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         resources:
           requests:
             memory: "4Gi"

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -92,6 +92,11 @@ presubmits:
         - name: PROJECT_PATH
           value: "{{ .projectPath }}"
         {{- end }}
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
         {{- if .envVars }}
         {{- range .envVars }}
         - name: {{ .Name }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For cases where we query the github api in a presubmit, like when installing kustomize, having a token avail will help increase our rate limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
