### PR TITLE
Change eks anywhere mocks presubmit to eks anywhere generate files presubmits

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-anywhere:
-  - name: eks-anywhere-mocks-presubmits
+  - name: eks-anywhere-generate-files-presubmits
     always_run: false
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*"
     cluster: "prow-presubmits-cluster"
@@ -46,7 +46,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          make verify-mocks
+          make verify-generate-files
         resources:
           requests:
             memory: "4Gi"

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -157,7 +157,7 @@ func MakeTargetCheck(jc *JobConstants) presubmitCheck {
 	return presubmitCheck(func(presubmitConfig config.Presubmit, fileContentsString string) (bool, int, string) {
 		if strings.Contains(presubmitConfig.JobBase.Name, "e2e") ||
 			strings.Contains(presubmitConfig.JobBase.Name, "lint") ||
-			strings.Contains(presubmitConfig.JobBase.Name, "mocks") ||
+			strings.Contains(presubmitConfig.JobBase.Name, "generate-files") ||
 			presubmitConfig.JobBase.Name == "eks-anywhere-attribution-files-presubmit" ||
 			presubmitConfig.JobBase.Name == "eks-anywhere-cluster-controller-tooling-presubmit" ||
 			presubmitConfig.JobBase.Name == "eks-anywhere-release-tooling-presubmit" ||

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -1,7 +1,7 @@
-jobName: eks-anywhere-mocks-presubmits
+jobName: eks-anywhere-generate-files-presubmits
 runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*
 commands:
-- make verify-mocks
+- make verify-generate-files
 resources:
   requests:
     memory: 4Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes to mock presubmit into a generate files presubmit check, which runs the new make target `verify-generate-files` added [here](https://github.com/aws/eks-anywhere/pull/6541).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
