### PR TITLE
Update EKS-A E2E test AMI ID

### DIFF
--- a/config/job-constants.yaml
+++ b/config/job-constants.yaml
@@ -24,7 +24,7 @@ env:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-0693f056dac11611c
+  value: ami-03ca4395b5b1e4aef
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"
         - name: INTEGRATION_TEST_AL2_AMI_ID
-          value: "ami-0693f056dac11611c"
+          value: "ami-03ca4395b5b1e4aef"
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -7,7 +7,7 @@ envVars:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-0693f056dac11611c
+  value: ami-03ca4395b5b1e4aef
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE


### PR DESCRIPTION
Update EKS-A E2E test AMI ID to latest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
