### PR TITLE
Skip running EKS-A CLI-related presubmits on release code changes

### DIFF
--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-cli-attribution-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
+    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-e2e-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
+    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
     branches:
     - ^main$
     cluster: "prow-presubmits-cluster"

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*"
+    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -64,7 +64,7 @@ type UnmarshaledJobConfig struct {
 
 type presubmitCheck func(presubmitConfig config.Presubmit, fileContentsString string) (passed bool, lineNo int, errorMessage string)
 
-func findLineNumber(fileContentsString string, searchString string) int {
+func findLineNumber(fileContentsString, searchString string) int {
 	fileLines := strings.Split(fileContentsString, "\n")
 
 	for lineNo, fileLine := range fileLines {
@@ -185,7 +185,7 @@ func MakeTargetCheck(jc *JobConstants) presubmitCheck {
 	})
 }
 
-func getFilesChanged(gitRoot string, pullBaseSha string, pullPullSha string) ([]string, error) {
+func getFilesChanged(gitRoot, pullBaseSha, pullPullSha string) ([]string, error) {
 	presubmitFiles := []string{}
 	gitDiffCommand := []string{"git", "-C", gitRoot, "diff", "--name-only", pullBaseSha, pullPullSha}
 	fmt.Println("\n", strings.Join(gitDiffCommand, " "))

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-cli-attribution-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*
+runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
 commands:
 - make generate-attribution
 resources:

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-e2e-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*
+runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
 imageBuild: true
 branches:
 - ^main$

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|release/.*|controllers/.*
+runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
 commands:
 - make build
 resources:

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/ghodss/yaml"
-
 	"github.com/aws/eks-distro-prow-jobs/templater/jobs/types"
+	"github.com/ghodss/yaml"
 )
 
 var releaseBranches = []string{
@@ -37,7 +36,7 @@ func GetJobsByType(repos []string, jobType string) (map[string]map[string]types.
 	return jobsListByType, nil
 }
 
-func AppendMap(current map[string]interface{}, new map[string]interface{}) map[string]interface{} {
+func AppendMap(current, new map[string]interface{}) map[string]interface{} {
 	newMap := map[string]interface{}{}
 	for k, v := range current {
 		newMap[k] = v

--- a/templater/main.go
+++ b/templater/main.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aws/eks-anywhere-prow-jobs/templater/jobs"
 	"github.com/aws/eks-distro-prow-jobs/templater/jobs/types"
 	"github.com/aws/eks-distro-prow-jobs/templater/jobs/utils"
+
+	"github.com/aws/eks-anywhere-prow-jobs/templater/jobs"
 )
 
 var (
@@ -165,7 +166,7 @@ func useTemplate(jobType string) (string, error) {
 	}
 }
 
-func clusterDetails(jobType string, cluster string, bucket string, serviceAccountName string) (string, string, string) {
+func clusterDetails(jobType, cluster, bucket, serviceAccountName string) (string, string, string) {
 	if jobType == "presubmit" && len(cluster) == 0 {
 		cluster = "prow-presubmits-cluster"
 		bucket = "s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp"


### PR DESCRIPTION
We don't need to run the EKS-A CLI build, attribution and E2E presubmits when release code changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
