### PR TITLE
Reserve ephemeral storage for upgrader presubmits

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -64,6 +64,7 @@ presubmits:
           requests:
             memory: "8Gi"
             cpu: "1024m"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: moby/buildkit:v0.12.5-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -11,3 +11,4 @@ resources:
   requests:
     memory: 8Gi
     cpu: 1024m
+    ephemeral-storage: 50Gi


### PR DESCRIPTION
*Issue #, if available:*
Reserve 50Gi ephemeral storage for upgrader presubmits jobs as the current builds are failing due to `no disk space left` error. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
