### PR TITLE
Scope down triggers for E2E presubmit and CLI presubmits further

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: eks-a-upgrader-image-presubmits
+  - name: eks-a-upgrader-image-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|projects/aws/upgrader/.*"
     cluster: "prow-presubmits-cluster"

--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-cli-attribution-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
+    run_if_changed: "^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-cluster-controller-tooling-presubmit
     always_run: false
-    run_if_changed: "^config/.*|^controllers/.*"
+    run_if_changed: "^config/.*|^controllers/.*|^manager/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-e2e-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
+    run_if_changed: "^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|test/.*|controllers/.*"
     branches:
     - ^main$
     cluster: "prow-presubmits-cluster"

--- a/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-anywhere:
-  - name: eks-anywhere-generate-files-presubmits
+  - name: eks-anywhere-generate-files-presubmit
     always_run: false
     run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*"
     cluster: "prow-presubmits-cluster"

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere:
   - name: eks-anywhere-presubmit
     always_run: false
-    run_if_changed: "Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*"
+    run_if_changed: "^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|controllers/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -1,4 +1,4 @@
-jobName: eks-a-upgrader-image-presubmits
+jobName: eks-a-upgrader-image-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|projects/aws/upgrader/.*
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-cli-attribution-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
+runIfChanged: ^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|controllers/.*
 commands:
 - make generate-attribution
 resources:

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-cluster-controller-tooling-presubmit
-runIfChanged: ^config/.*|^controllers/.*
+runIfChanged: ^config/.*|^controllers/.*|^manager/.*
 imageBuild: true
 commands:
 - make build-cluster-controller

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-e2e-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
+runIfChanged: ^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|test/.*|controllers/.*
 imageBuild: true
 branches:
 - ^main$

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -1,4 +1,4 @@
-jobName: eks-anywhere-generate-files-presubmits
+jobName: eks-anywhere-generate-files-presubmit
 runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*
 commands:
 - make verify-generate-files

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -1,5 +1,5 @@
 jobName: eks-anywhere-presubmit
-runIfChanged: Makefile|cmd/.*|flux/.*|go.mod|go.sum|hack/.*|internal/.*|pkg/.*|test/.*|controllers/.*
+runIfChanged: ^Makefile|^cmd/.*|^go.mod$|^go.sum$|hack/.*|internal/.*|^pkg/.*|controllers/.*
 commands:
 - make build
 resources:


### PR DESCRIPTION
Scope down triggers for E2E presubmit and CLI presubmits even further using the proper regex.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
