### PR TITLE
Add pre-submits for release branch 1-30

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/autoscaler"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -20,9 +20,9 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: cloud-provider-aws-1-29-tooling-presubmit
+  - name: autoscaler-1-30-presubmit
     always_run: false
-    run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10
@@ -49,21 +49,23 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/cloud-provider-aws"
+          value: "projects/kubernetes/autoscaler"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: public-access-github-token
               key: token
         - name: RELEASE_BRANCH
-          value: "1-29"
+          value: "1-30"
+        - name: PRUNE_BUILDCTL
+          value: "true"
         resources:
           requests:
             memory: "16Gi"
-            cpu: "4"
+            cpu: "8"
       - name: buildkitd
         image: moby/buildkit:v0.12.5-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: cloud-provider-aws-1-29-tooling-presubmit
+  - name: cloud-provider-aws-1-30-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
     cluster: "prow-presubmits-cluster"
@@ -49,7 +49,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-aws"
@@ -59,7 +59,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: RELEASE_BRANCH
-          value: "1-29"
+          value: "1-30"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes/cloud-provider-vsphere"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
@@ -20,9 +20,9 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: cloud-provider-aws-1-29-tooling-presubmit
+  - name: cloud-provider-vsphere-1-30-tooling-presubmit
     always_run: false
-    run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-vsphere/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10
@@ -49,17 +49,19 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/cloud-provider-aws"
+          value: "projects/kubernetes/cloud-provider-vsphere"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: public-access-github-token
               key: token
         - name: RELEASE_BRANCH
-          value: "1-29"
+          value: "1-30"
+        - name: PRUNE_BUILDCTL
+          value: "true"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/image-builder"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
@@ -20,9 +20,9 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: cloud-provider-aws-1-29-tooling-presubmit
+  - name: imagebuilder-1-30-presubmit
     always_run: false
-    run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    run_if_changed: "EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes-sigs/image-builder/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10
@@ -33,11 +33,13 @@ presubmits:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
     labels:
-      image-build: "true"
       disk-usage: "true"
     spec:
       serviceaccountName: presubmits-build-account
       automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1100
+        runAsGroup: 1100
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
@@ -47,32 +49,27 @@ presubmits:
         - >
           trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
           &&
-          build/lib/buildkit_check.sh
-          &&
-          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/cloud-provider-aws"
+          value: "projects/kubernetes-sigs/image-builder"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: public-access-github-token
               key: token
         - name: RELEASE_BRANCH
-          value: "1-29"
+          value: "1-30"
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: CODEBUILD_ROLE_ARN
+          value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
+        - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
+          value: "d3r9quwvrhi0m2.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"
-            cpu: "4"
-      - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
-        command:
-        - sh
-        args:
-        - /script/entrypoint.sh
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
+            cpu: "8"
       - command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
           value: "projects/kubernetes-sigs/kind"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -20,9 +20,9 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: cloud-provider-aws-1-29-tooling-presubmit
+  - name: kind-1-30-tooling-presubmit
     always_run: false
-    run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_KIND_AL2023_TAG_FILE|EKSD_LATEST_RELEASES|^build/lib/.*|Common.mk|projects/kubernetes-sigs/kind/.*"
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10
@@ -49,17 +49,19 @@ presubmits:
           &&
           build/lib/buildkit_check.sh
           &&
-          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+          if make check-for-supported-release-branch -C $PROJECT_PATH; then if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi; fi
         env:
         - name: PROJECT_PATH
-          value: "projects/kubernetes/cloud-provider-aws"
+          value: "projects/kubernetes-sigs/kind"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: public-access-github-token
               key: token
         - name: RELEASE_BRANCH
-          value: "1-29"
+          value: "1-30"
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -18,6 +18,7 @@ var releaseBranches = []string{
 	"1-27",
 	"1-28",
 	"1-29",
+	"1-30",
 }
 
 func GetJobsByType(repos []string, jobType string) (map[string]map[string]types.JobConfig, error) {


### PR DESCRIPTION
*Issue #, if available:*
Add pre-submits for projects in build tooling for new release branch 1-30.

*Description of changes:*
Add 1-30 as a supported release branch and `run make prowjobs -C templater` .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
