### PR TITLE
Update builder base image to latest

### DIFF
--- a/BUILDER_BASE_TAG_FILE
+++ b/BUILDER_BASE_TAG_FILE
@@ -1,1 +1,1 @@
-standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-25-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-25-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-25-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-26-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-26-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-25-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-26-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
@@ -42,7 +42,8 @@ presubmits:
         arch: "ARM64"
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.19.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.19.yaml
@@ -43,7 +43,8 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -43,7 +43,8 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
         runAsGroup: 1100
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-25-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-26-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
@@ -42,7 +42,8 @@ presubmits:
         arch: "ARM64"
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
@@ -42,7 +42,8 @@ presubmits:
         arch: "ARM64"
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
@@ -40,7 +40,8 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
@@ -47,7 +47,8 @@ postsubmits:
         arch: "AMD64"
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-periodic.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-periodic.yaml
@@ -40,7 +40,8 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -40,7 +40,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-development-bundle-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-development-bundle-presubmit.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-development-eks-a-release-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-development-eks-a-release-presubmit.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -39,7 +39,8 @@ periodics:
     automountServiceAccountToken: false
     containers:
     - name: build-container
-      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+      image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -42,7 +42,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-validate-tinkerbell-hardware-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-validate-tinkerbell-hardware-presubmits.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-production-bundle-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-production-bundle-presubmit.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-production-eks-a-release-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-production-eks-a-release-presubmit.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -39,7 +39,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
@@ -41,7 +41,8 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-2d6e96cf6f92fe90c7f9bfa6fac36583c7eb4b0f.2
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-a8c3bcd8c8fa6aa4bba0c19041d0e9f0c3a09a06.2
+
         command:
         - bash
         - -c


### PR DESCRIPTION
*Issue #, if available:*
The [PR](https://github.com/aws/eks-anywhere-prow-jobs/pull/380) for base image update from PR bot seems to be raised before we added the new release branch support for 1-30. So the pre-submits for 1-30 have been failing on that PR. This change manually updates the builder base image tag to latest and updates the corresponding prow jobs.  

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
