### PR TITLE
Update BR cloudfront endpoint

### DIFF
--- a/config/job-constants.yaml
+++ b/config/job-constants.yaml
@@ -32,4 +32,4 @@ env:
 - name: IMAGE_REPO
   value: public.ecr.aws/h1r8a7l5
 - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-  value: d3r9quwvrhi0m2.cloudfront.net
+  value: d157u5k0sfp276.cloudfront.net

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-25-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-26-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - name: CODEBUILD_ROLE_ARN
           value: "arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole"
         - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-          value: "d3r9quwvrhi0m2.cloudfront.net"
+          value: "d157u5k0sfp276.cloudfront.net"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/imagebuilder-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/imagebuilder-1-X-presubmits.yaml
@@ -11,7 +11,7 @@ envVars:
 - name: CODEBUILD_ROLE_ARN
   value: arn:aws:iam::857151390494:role/ImageBuilderPresubmitRole
 - name: BOTTLEROCKET_CLOUDFRONT_ENDPOINT
-  value: d3r9quwvrhi0m2.cloudfront.net
+  value: d157u5k0sfp276.cloudfront.net
 resources:
   requests:
     memory: 16Gi


### PR DESCRIPTION
*Issue #, if available:*
The cloudfront endpoint is used by our presubmits to build ovas for a new kubernetes version that is still not officially released by BottleRocket. We were using this endpoint that the BR team shared us during 1.29 version. The previous link doesn't exist anymore and they provided the 1.30 ova in a new Cloudfront link. Updating the cloudfront resource to be able to build 130 BR ovas.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
