### PR TITLE
Update E2E test AMI to latest

### DIFF
--- a/config/job-constants.yaml
+++ b/config/job-constants.yaml
@@ -24,7 +24,7 @@ env:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-001d69cfd804e66d2
+  value: ami-0b70e2b2e84d240fb
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
         - name: TEST_ROLE_ARN
           value: "arn:aws:iam::025778587028:role/EksaTestBuildRole"
         - name: INTEGRATION_TEST_AL2_AMI_ID
-          value: "ami-001d69cfd804e66d2"
+          value: "ami-0b70e2b2e84d240fb"
         - name: INTEGRATION_TEST_STORAGE_BUCKET
           value: "testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4"
         - name: INTEGRATION_TEST_INSTANCE_PROFILE

--- a/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -7,7 +7,7 @@ envVars:
 - name: TEST_ROLE_ARN
   value: arn:aws:iam::025778587028:role/EksaTestBuildRole
 - name: INTEGRATION_TEST_AL2_AMI_ID
-  value: ami-001d69cfd804e66d2
+  value: ami-0b70e2b2e84d240fb
 - name: INTEGRATION_TEST_STORAGE_BUCKET
   value: testbuildstack-025778587-eksaintegrationtestresou-1tqbb00woona4
 - name: INTEGRATION_TEST_INSTANCE_PROFILE


### PR DESCRIPTION
This PR updates the E2E test AMI to the latest image from the build pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
