### PR TITLE
Rename charts presubmit to tinkerbell-stack presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
@@ -20,7 +20,7 @@
 
 presubmits:
   aws/eks-anywhere-build-tooling:
-  - name: charts-presubmit
+  - name: tinkerbell-stack-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/tinkerbell/charts/.*"
     cluster: "prow-presubmits-cluster"

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
@@ -1,4 +1,4 @@
-jobName: charts-presubmit
+jobName: tinkerbell-stack-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/tinkerbell/charts/.*
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rename charts presubmit to tinkerbell-stack presubmit to remove ambiguity in the presubmit name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.