### PR TITLE
only run packges presubmits on main

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-26-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: autoscaler-1-26-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: autoscaler-1-27-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: autoscaler-1-28-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: autoscaler-1-29-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: autoscaler-1-30-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: aws-otel-collector-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-observability/aws-otel-collector/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: distribution-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/distribution/distribution/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: emissary-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_PYTHON_3.9_AL2023_TAG_FILE|^build/lib/.*|Common.mk|projects/emissary-ingress/emissary/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: harbor-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/goharbor/harbor/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: harbor-scanner-trivy-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aquasecurity/harbor-scanner-trivy/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: hello-eks-anywhere-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-containers/hello-eks-anywhere/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: metallb-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/metallb/metallb/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: metrics-server-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes-sigs/metrics-server/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: prometheus-node-exporter-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/node_exporter/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: prometheus-prometheus-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/prometheus/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: redis-tooling-presubmit
     always_run: false
     run_if_changed: "EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/redis/redis/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: trivy-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/aquasecurity/trivy/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/autoscaler-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/autoscaler-1-X-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: autoscaler-{{ .releaseBranch }}-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/kubernetes/autoscaler/.*
+branches:
+- ^main$
 imageBuild: true
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: aws-otel-collector-tooling-presubmit
 runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-observability/aws-otel-collector/.*
+branches:
+- ^main$
 imageBuild: true
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: distribution-tooling-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/distribution/distribution/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/distribution/distribution

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: emissary-tooling-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_PYTHON_3.9_AL2023_TAG_FILE|^build/lib/.*|Common.mk|projects/emissary-ingress/emissary/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/emissary-ingress/emissary

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: harbor-tooling-presubmit
 runIfChanged: EKS_DISTRO_BASE_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/goharbor/harbor/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/goharbor/harbor

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: harbor-scanner-trivy-tooling-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/aquasecurity/harbor-scanner-trivy/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/aquasecurity/harbor-scanner-trivy

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: hello-eks-anywhere-tooling-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_NGINX_TAG_FILE|^build/lib/.*|Common.mk|projects/aws-containers/hello-eks-anywhere/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/aws-containers/hello-eks-anywhere

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: metallb-tooling-presubmit
 runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/metallb/metallb/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/metallb/metallb

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: metrics-server-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/kubernetes-sigs/metrics-server/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/kubernetes-sigs/metrics-server

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: prometheus-node-exporter-tooling-presubmit
 runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/node_exporter/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/prometheus/node_exporter

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: prometheus-prometheus-tooling-presubmit
 runIfChanged: EKS_DISTRO_BASE_TAG_FILE|^build/lib/.*|Common.mk|projects/prometheus/prometheus/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/prometheus/prometheus

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: redis-tooling-presubmit
 runIfChanged: EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE|^build/lib/.*|Common.mk|projects/redis/redis/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/redis/redis

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -1,5 +1,7 @@
 jobName: trivy-tooling-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/aquasecurity/trivy/.*
+branches:
+- ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
 projectPath: projects/aquasecurity/trivy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We only build/release packages off of main in codebuild. We can skip these presubmits on release branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
