### PR TITLE
Include kubernetes/cloud-provider-aws presubmit job to run only on main

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-26-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-26-presubmit.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: cloud-provider-aws-1-26-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: cloud-provider-aws-1-27-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: cloud-provider-aws-1-28-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: cloud-provider-aws-1-29-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -23,6 +23,8 @@ presubmits:
   - name: cloud-provider-aws-1-30-tooling-presubmit
     always_run: false
     run_if_changed: "^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*"
+    branches:
+    - ^main$
     cluster: "prow-presubmits-cluster"
     error_on_eviction: true
     max_concurrency: 10

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/cloud-provider-aws-1-X-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/cloud-provider-aws-1-X-presubmit.yaml
@@ -1,5 +1,7 @@
 jobName: cloud-provider-aws-{{ .releaseBranch }}-tooling-presubmit
 runIfChanged: ^build/lib/.*|Common.mk|projects/kubernetes/cloud-provider-aws/.*
+branches:
+- ^main$
 imageBuild: true
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi


### PR DESCRIPTION
*Description of changes:*
Packages were made to run only on main in https://github.com/aws/eks-anywhere-prow-jobs/pull/402 but it missed the `kubernetes/cloud-provider-aws` project which is a dependency of packages. This PR includes that project in the list of packages presubmits jobs to run only on main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
