### PR TITLE
fixes hook amd presubmit to use proper env var

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
@@ -61,8 +61,6 @@ presubmits:
               key: token
         - name: BINARY_PLATFORMS
           value: "linux/amd64"
-        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-          value: "true"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -66,7 +66,7 @@ presubmits:
           value: "localhost:5000"
         - name: IMAGE_PLATFORMS
           value: "linux/amd64"
-        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+        - name: FAKE_ARM_BINARIES_FOR_VALIDATION
           value: "true"
         resources:
           requests:

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
@@ -61,8 +61,6 @@ presubmits:
               key: token
         - name: BINARY_PLATFORMS
           value: "linux/amd64"
-        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-          value: "true"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -61,8 +61,6 @@ presubmits:
               key: token
         - name: BINARY_PLATFORMS
           value: "linux/amd64"
-        - name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-          value: "true"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         resources:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/containerd-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/containerd-presubmits.yaml
@@ -6,8 +6,6 @@ projectPath: projects/containerd/containerd
 envVars:
 - name: BINARY_PLATFORMS
   value: linux/amd64
-- name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-  value: true
 - name: ARTIFACTS_BUCKET
   value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 imageBuild: true

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -10,7 +10,7 @@ envVars:
   value: localhost:5000
 - name: IMAGE_PLATFORMS
   value: linux/amd64
-- name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
+- name: FAKE_ARM_BINARIES_FOR_VALIDATION
   value: true
 resources:
   requests:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/runc-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/runc-presubmits.yaml
@@ -6,8 +6,6 @@ projectPath: projects/opencontainers/runc
 envVars:
 - name: BINARY_PLATFORMS
   value: linux/amd64
-- name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-  value: true
 - name: ARTIFACTS_BUCKET
   value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 imageBuild: true

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -6,8 +6,6 @@ projectPath: projects/fluxcd/source-controller
 envVars:
 - name: BINARY_PLATFORMS
   value: linux/amd64
-- name: FAKE_ARM_ARTIFACTS_FOR_VALIDATION
-  value: true
 - name: ARTIFACTS_BUCKET
   value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 imageBuild: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When I added the arm build I copied the env var from other presubmit jobs.  The one we were using is wrong, we changed at one point and never updated these jobs.  The actual env var is, `FAKE_ARM_BINARIES_FOR_VALIDATION`, per https://github.com/aws/eks-anywhere-build-tooling/blob/main/Common.mk#L452.  We do not to usually set it because its auto set based on the `binary_platforms`

The hook build is a bit different because I left the amd build building both binary platforms, because it can, most of the other examples cannot because they are cross compiling use CGO.  I left it this way so that checksum updates is a bit easier. So for this presubmit I am going to set the fake explicitly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
