### PR TITLE
Move PR title condition to run command

### DIFF
--- a/.github/workflows/baseimage-pr-notifier.yml
+++ b/.github/workflows/baseimage-pr-notifier.yml
@@ -5,9 +5,13 @@ on:
 jobs:
   baseimage-pr-notifier:
     runs-on: ubuntu-latest
-    
-    if: ${{ contains(github.event.pull_request.title, 'Update base image') }}
+
     steps:
-      - run: curl -d '{"key":"base image"}' -X POST $SLACK_WEBHOOK
+      - run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ "Update base image" ]]; then
+            curl -d '{"key":"builder-base image"}' -X POST $SLACK_WEBHOOK
+          fi
+          exit 0
+        shell: bash
         env:
           SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/builder-baseimage-pr-notifier.yml
+++ b/.github/workflows/builder-baseimage-pr-notifier.yml
@@ -5,9 +5,13 @@ on:
 jobs:
   builder-baseimage-pr-notifier:
     runs-on: ubuntu-latest
-    
-    if: ${{ contains(github.event.pull_request.title, 'Update builder-base') }}
+
     steps:
-      - run: curl -d '{"key":"builder-base image"}' -X POST $SLACK_WEBHOOK
+      - run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ "Update builder-base" ]]; then
+            curl -d '{"key":"builder-base image"}' -X POST $SLACK_WEBHOOK
+          fi
+          exit 0
+        shell: bash
         env:
           SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The current version of Prow doesn't recognize `Skipped` as a valid GitHub Action conclusion, so workflows that get skipped due to the `if` condition cause the PR to remain open because Tide can't auto-merge the PR. So instead of having GitHub do the check and mark the action as `Skipped`, we always run it but have the `if` check in the command to skip posting to Slack if the title doesn't pass the check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
