### PR TITLE
adds artifacts bucket to hook build

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
@@ -64,6 +64,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: BINARY_PLATFORMS
           value: "linux/arm64"
         - name: IMAGE_PLATFORMS

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -62,6 +62,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ARTIFACTS_BUCKET
+          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: IMAGE_REPO
           value: "localhost:5000"
         - name: IMAGE_PLATFORMS

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
@@ -10,6 +10,8 @@ projectPath: projects/tinkerbell/hook
 imageBuild: true
 localRegistry: true
 envVars:
+- name: ARTIFACTS_BUCKET
+  value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 - name: BINARY_PLATFORMS
   value: linux/arm64
 - name: IMAGE_PLATFORMS

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -6,6 +6,8 @@ projectPath: projects/tinkerbell/hook
 imageBuild: true
 localRegistry: true
 envVars:
+- name: ARTIFACTS_BUCKET
+  value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 - name: IMAGE_REPO
   value: localhost:5000
 - name: IMAGE_PLATFORMS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When upgrading the hook project we are going to start producing a containerd container image instead of using upstream.  The presubmit will need to artifacts bucket to download the built tars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
