### PR TITLE
Add more space to bottlerocket bootstrap presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -67,6 +67,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "8"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: moby/buildkit:v0.12.5-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -13,3 +13,4 @@ resources:
   requests:
     memory: 16Gi
     cpu: 8
+    ephemeral-storage: "50Gi"


### PR DESCRIPTION
*Description of changes:*
Reserve 50Gi ephemeral storage for bottlerocket-bootstrap presubmit job as the current build on [#3706](https://github.com/aws/eks-anywhere-build-tooling/pull/3706) is failing due to no space left on device error.
```
------------------- 2024-09-01T07:50:07.525+0000 Starting target=bottlerocket-bootstrap/images/amd64 -------------------
------
 > importing cache manifest from 316434458148.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v1-31-2-latest:
------
error: failed to solve: mkdir /home/user/.local/share/buildkit/runc-native/content/ingest/1693853be0f444c3cc6a48665f61ff0d7b6cc59bb0326be180ad986db43580ea: no space left on device
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
