### PR TITLE
adds additional image cache repos to presubmits

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "1-27"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "1-28"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "1-29"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "1-30"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "1-31"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: RELEASE_BRANCH
           value: "1-27"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: RELEASE_BRANCH
           value: "1-28"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: RELEASE_BRANCH
           value: "1-29"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: RELEASE_BRANCH
           value: "1-30"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: RELEASE_BRANCH
           value: "1-31"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-27"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-28"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-29"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-30"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-31"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "linux/arm64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "linux/amd64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.20.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.20.yaml
@@ -57,6 +57,8 @@ periodics:
       env:
       - name: PULL_BASE_REF
         value: "release-0.20"
+      - name: ADDITIONAL_IMAGE_CACHE_REPOS
+        value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
       resources:
         requests:
           memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -54,6 +54,9 @@ periodics:
         build/lib/buildkit_check.sh
         &&
         make update-attribution-files
+      env:
+      - name: ADDITIONAL_IMAGE_CACHE_REPOS
+        value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
       resources:
         requests:
           memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
               key: token
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "4Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
@@ -72,6 +72,8 @@ presubmits:
           value: "linux/arm64"
         - name: IMAGE_REPO
           value: "localhost:5000"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit.yaml
@@ -72,6 +72,8 @@ presubmits:
           value: "true"
         - name: LINUXKIT_IMAGE_REPO
           value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-27"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-28"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-29"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-30"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "1-31"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
         - name: PRUNE_BUILDCTL
           value: "true"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
@@ -65,6 +65,8 @@ presubmits:
           value: "linux/arm64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "linux/amd64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits-arm64.yaml
@@ -67,6 +67,8 @@ presubmits:
           value: "linux/arm64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -63,6 +63,8 @@ presubmits:
           value: "linux/amd64"
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
               key: token
         - name: ARTIFACTS_BUCKET
           value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -61,6 +61,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -59,6 +59,8 @@ presubmits:
             secretKeyRef:
               name: public-access-github-token
               key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -51,6 +51,14 @@ presubmits:
           build/lib/buildkit_check.sh
           &&
           make build-cluster-controller
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: public-access-github-token
+              key: token
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -67,6 +67,8 @@ presubmits:
           value: "EksaE2eSsmBuildRole"
         - name: IMAGE_REPO
           value: "public.ecr.aws/h1r8a7l5"
+        - name: ADDITIONAL_IMAGE_CACHE_REPOS
+          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/templater/main.go
+++ b/templater/main.go
@@ -74,6 +74,10 @@ func main() {
 					envVars = append(envVars, &types.EnvVar{Name: "USE_BUILDX", Value: "true"})
 				}
 
+				if jobConfig.ImageBuild {
+					envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"})
+				}
+
 				cluster, bucket, serviceAccountName := clusterDetails(jobType, jobConfig.Cluster, jobConfig.Bucket, jobConfig.ServiceAccountName)
 
 				data := map[string]interface{}{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This allows presubmits to pull image cache from the eks-a build account.  This should have a margin time improvement for most builds, but for some

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
