### PR TITLE
Remove spurious newline in Prowjobs

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cilium-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-amd64.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/dhcp-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/dhcp-presubmits-amd64.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/dhcp-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/dhcp-presubmits-arm64.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.20.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.20.yaml
@@ -44,7 +44,6 @@ periodics:
     containers:
     - name: build-container
       image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -44,7 +44,6 @@ periodics:
     containers:
     - name: build-container
       image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
@@ -44,7 +44,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-27-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-28-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-29-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-30-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/imagebuilder-1-31-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/ipxedust-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/ipxedust-presubmits-amd64.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/ipxedust-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/ipxedust-presubmits-arm64.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits-amd64.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linux-bootconfig-presubmits-arm64.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-amd64.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-arm64.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-amd64.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -43,7 +43,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/validate-generated-presubmit.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-generatebundle-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-packages/eks-anywhere-packages-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-prow-jobs/eks-anywhere-prowjobs-lint-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
+++ b/jobs/aws/eks-anywhere/cli-generate-golden-files-periodics.yaml
@@ -41,7 +41,6 @@ periodics:
     containers:
     - name: build-container
       image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-brew-update-postsubmits.yaml
@@ -48,7 +48,6 @@ postsubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-periodic.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-periodic.yaml
@@ -41,7 +41,6 @@ periodics:
     containers:
     - name: build-container
       image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cli-attribution-presubmit.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-development-bundle-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-development-bundle-presubmit.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-development-eks-a-release-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-development-eks-a-release-presubmit.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-docs-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-cleanup-periodics.yaml
@@ -40,7 +40,6 @@ periodics:
     containers:
     - name: build-container
       image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
       command:
       - bash
       - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -41,7 +41,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-validate-tinkerbell-hardware-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-validate-tinkerbell-hardware-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-generate-files-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-production-bundle-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-production-bundle-presubmit.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-production-eks-a-release-presubmit.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-production-eks-a-release-presubmit.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-presubmits.yaml
@@ -40,7 +40,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-release-tooling-test-presubmits.yaml
@@ -42,7 +42,6 @@ presubmits:
       containers:
       - name: build-container
         image: public.ecr.aws/eks-distro-build-tooling/builder-base:standard-28b4873f3cf874f08f46be06510bd931658072d9.2
-
         command:
         - bash
         - -c

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -14,7 +14,7 @@
 #
 {{ .editWarning }}
 
-{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag -}}
+{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag | trim -}}
 periodics:
 - name: {{ .prowjobName }}
   cron: "{{ .cronExpression }}"

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -14,7 +14,7 @@
 #
 {{ .editWarning }}
 
-{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag -}}
+{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag | trim -}}
 postsubmits:
   {{ .repoName }}:
   - name: {{ .prowjobName }}

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -14,7 +14,7 @@
 #
 {{ .editWarning }}
 
-{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag -}}
+{{ $builderBaseImage := printf "%s:%s" "public.ecr.aws/eks-distro-build-tooling/builder-base" .builderBaseTag | trim -}}
 presubmits:
   {{ .repoName }}:
   - name: {{ .prowjobName }}


### PR DESCRIPTION
A newline was added to all Prowjobs in #386 because of a trailing newline to the builder-base tag file. Removing that by trimming the image URI constructed in the Go template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
