### PR TITLE
Update artifacts bucket for packages prow jobs

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -63,7 +63,7 @@ presubmits:
         - name: RELEASE_BRANCH
           value: "1-27"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -63,7 +63,7 @@ presubmits:
         - name: RELEASE_BRANCH
           value: "1-28"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -63,7 +63,7 @@ presubmits:
         - name: RELEASE_BRANCH
           value: "1-29"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -63,7 +63,7 @@ presubmits:
         - name: RELEASE_BRANCH
           value: "1-30"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
@@ -63,7 +63,7 @@ presubmits:
         - name: RELEASE_BRANCH
           value: "1-31"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+          value: "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
           value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
         resources:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
         - name: ARTIFACTS_BUCKET
           value: "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
         - name: IMAGE_TAG_SUFFIX
           value: "-amd64"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
         - name: IMAGE_TAG_SUFFIX
           value: "-amd64"
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ARTIFACTS_BUCKET
-          value: "s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f"
+          value: "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
         - name: PRUNE_BUILDCTL
           value: "true"
         - name: IMAGE_TAG_SUFFIX

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "8Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
               name: public-access-github-token
               key: token
         - name: ADDITIONAL_IMAGE_CACHE_REPOS
-          value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"
+          value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"
         resources:
           requests:
             memory: "16Gi"

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -29,6 +29,8 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/test-infra/prow/config"
 	yaml "sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere-prow-jobs/templater/jobs"
 )
 
 const (
@@ -81,8 +83,7 @@ func EnvVarsCheck(jc *JobConstants) presubmitCheck {
 			for _, env := range container.Env {
 				if index, exists := jc.envVarExist(env.Name); exists {
 					// check deepequal in case we decide to support EnvVarSource values in the future
-					if presubmitConfig.JobBase.Name == "eks-anywhere-packages-image-tooling-presubmit" ||
-						presubmitConfig.JobBase.Name == "harbor-tooling-presubmit" {
+					if jobs.IsCuratedPackagesPresubmit(presubmitConfig.JobBase.Name) {
 						jc.EnvVars[index].Value = "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
 					}
 					if env != jc.EnvVars[index] {

--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -82,6 +81,10 @@ func EnvVarsCheck(jc *JobConstants) presubmitCheck {
 			for _, env := range container.Env {
 				if index, exists := jc.envVarExist(env.Name); exists {
 					// check deepequal in case we decide to support EnvVarSource values in the future
+					if presubmitConfig.JobBase.Name == "eks-anywhere-packages-image-tooling-presubmit" ||
+						presubmitConfig.JobBase.Name == "harbor-tooling-presubmit" {
+						jc.EnvVars[index].Value = "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
+					}
 					if env != jc.EnvVars[index] {
 						lineToFind := fmt.Sprintf("name: %s", env.Name)
 						correctiveAction := fmt.Sprintf("Incorrect env var declared for %s in the %s container, update it to %s", env.Name, container.Name, env)
@@ -106,7 +109,7 @@ func AlwaysRunCheck() presubmitCheck {
 func SkipReportCheck() presubmitCheck {
 	return presubmitCheck(func(presubmitConfig config.Presubmit, fileContentsString string) (bool, int, string) {
 		if presubmitConfig.Reporter.SkipReport {
-			return false, findLineNumber(fileContentsString, "skip_report:"), "Please set always_run to false"
+			return false, findLineNumber(fileContentsString, "skip_report:"), "Please set skip_report to false"
 		}
 		return true, 0, ""
 	})
@@ -217,7 +220,7 @@ func unmarshalJobFile(filePath string, jobConfig *config.JobConfig) *Unmarshaled
 }
 
 func unmarshalYamlFile(filePath string, data interface{}) string {
-	fileContents, fileReadError := ioutil.ReadFile(filePath)
+	fileContents, fileReadError := os.ReadFile(filePath)
 
 	if fileReadError != nil {
 		log.Fatalf("Error reading contents of %s: %v", filePath, fileReadError)

--- a/templater/jobs/jobs.go
+++ b/templater/jobs/jobs.go
@@ -12,24 +12,24 @@ func GetJobList(jobType string) (map[string]map[string]types.JobConfig, error) {
 		repos := []string{"eks-anywhere", "eks-anywhere-build-tooling"}
 		periodicsList, err := GetJobsByType(repos, "periodic")
 		if err != nil {
-			return nil, fmt.Errorf("error getting periodic list:%v", err)
+			return nil, fmt.Errorf("getting periodic list:%v", err)
 		}
 		return periodicsList, nil
 	case "postsubmit":
 		repos := []string{"eks-anywhere"}
 		postsubmitsList, err := GetJobsByType(repos, "postsubmit")
 		if err != nil {
-			return nil, fmt.Errorf("error getting postsubmits list:%v", err)
+			return nil, fmt.Errorf("getting postsubmits list:%v", err)
 		}
 		return postsubmitsList, nil
 	case "presubmit":
 		repos := []string{"eks-anywhere", "eks-anywhere-build-tooling", "eks-anywhere-packages", "eks-anywhere-prow-jobs"}
 		presubmitsList, err := GetJobsByType(repos, "presubmit")
 		if err != nil {
-			return nil, fmt.Errorf("error getting presubmits list:%v", err)
+			return nil, fmt.Errorf("getting presubmits list:%v", err)
 		}
 		return presubmitsList, nil
 	default:
-		return nil, fmt.Errorf("Unsupported job type: %s", jobType)
+		return nil, fmt.Errorf("unsupported job type: %s", jobType)
 	}
 }

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -6,7 +6,7 @@ projectPath: projects/aws/eks-anywhere-packages
 imageBuild: true
 envVars:
 - name: ARTIFACTS_BUCKET
-  value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+  value: s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq
 resources:
   requests:
     memory: 16Gi

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -8,7 +8,7 @@ projectPath: projects/goharbor/harbor
 imageBuild: true
 envVars:
 - name: ARTIFACTS_BUCKET
-  value: s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+  value: s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq
 - name: PRUNE_BUILDCTL
   value: true
 - name: IMAGE_TAG_SUFFIX

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -185,3 +185,20 @@ func GenerateJobConfig(data interface{}, filePath string) (types.JobConfig, erro
 	}
 	return jobConfig, nil
 }
+
+func IsCuratedPackagesPresubmit(config string) bool {
+	return strings.Contains(config, "autoscaler") ||
+			strings.Contains(config, "cloud-provider-aws") ||
+			strings.Contains(config, "harbor") ||
+			strings.Contains(config, "prometheus") ||
+			config == "aws-otel-collector-tooling-presubmit" ||
+			config == "distribution-tooling-presubmit" ||
+			config == "eks-anywhere-packages-image-tooling-presubmit" ||
+			config == "emissary-tooling-presubmit" ||
+			config == "hello-eks-anywhere-tooling-presubmit" ||
+			config == "metallb-tooling-presubmit" ||
+			config == "metrics-server-presubmit" ||
+			config == "redis-tooling-presubmit" ||
+			config == "rolesanywhere-credential-helper-presubmit" ||
+			config == "trivy-tooling-presubmit"
+}

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -3,7 +3,6 @@ package jobs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -27,7 +26,7 @@ func GetJobsByType(repos []string, jobType string) (map[string]map[string]types.
 
 		jobList, err := UnmarshalJobs(jobDir)
 		if err != nil {
-			return nil, fmt.Errorf("error reading job directory %s: %v", jobDir, err)
+			return nil, fmt.Errorf("reading job directory %s: %v", jobDir, err)
 		}
 
 		jobsListByType[fmt.Sprintf("aws/%s", repo)] = jobList
@@ -97,9 +96,9 @@ func RunMappers(jobsToData map[string]map[string]interface{}, mappers []func(str
 }
 
 func UnmarshalJobs(jobDir string) (map[string]types.JobConfig, error) {
-	files, err := ioutil.ReadDir(jobDir)
+	files, err := os.ReadDir(jobDir)
 	if err != nil {
-		return nil, fmt.Errorf("error reading job directory %s: %v", jobDir, err)
+		return nil, fmt.Errorf("reading job directory %s: %v", jobDir, err)
 	}
 
 	var mappers []func(string, map[string]interface{}) map[string]map[string]interface{}
@@ -150,37 +149,37 @@ func ExecuteTemplate(templateContent string, data interface{}) ([]byte, error) {
 
 	temp, err := temp.Parse(templateContent)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing template: %v", err)
+		return nil, fmt.Errorf("parsing template: %v", err)
 	}
 
 	var buf bytes.Buffer
 	err = temp.Execute(&buf, data)
 	if err != nil {
-		return nil, fmt.Errorf("error substituting values for template: %v", err)
+		return nil, fmt.Errorf("substituting values for template: %v", err)
 	}
 	return buf.Bytes(), nil
 }
 
 func GenerateJobConfig(data interface{}, filePath string) (types.JobConfig, error) {
 	var jobConfig types.JobConfig
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
-		return jobConfig, fmt.Errorf("error reading job YAML %s: %v", filePath, err)
+		return jobConfig, fmt.Errorf("reading job YAML %s: %v", filePath, err)
 	}
 	var templatedContents []byte
 	if data != nil {
 		templatedContents, err = ExecuteTemplate(string(contents), data)
 		if err != nil {
-			return jobConfig, fmt.Errorf("error executing template: %v", err)
+			return jobConfig, fmt.Errorf("executing template: %v", err)
 		}
 		err = yaml.Unmarshal(templatedContents, &jobConfig)
 		if err != nil {
-			return jobConfig, fmt.Errorf("error unmarshaling contents of file %s: %v", filePath, err)
+			return jobConfig, fmt.Errorf("unmarshaling contents of file %s: %v", filePath, err)
 		}
 	} else {
 		err = yaml.Unmarshal(contents, &jobConfig)
 		if err != nil {
-			return jobConfig, fmt.Errorf("error unmarshaling contents of file %s: %v", filePath, err)
+			return jobConfig, fmt.Errorf("unmarshaling contents of file %s: %v", filePath, err)
 		}
 	}
 	return jobConfig, nil

--- a/templater/main.go
+++ b/templater/main.go
@@ -74,7 +74,24 @@ func main() {
 				}
 
 				if jobConfig.ImageBuild {
-					envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"})
+					if strings.Contains(jobConfig.JobName, "autoscaler") ||
+						strings.Contains(jobConfig.JobName, "cloud-provider-aws") ||
+						strings.Contains(jobConfig.JobName, "harbor") ||
+						strings.Contains(jobConfig.JobName, "prometheus") ||
+						jobConfig.JobName == "aws-otel-collector-tooling-presubmit" ||
+						jobConfig.JobName == "distribution-tooling-presubmit" ||
+						jobConfig.JobName == "eks-anywhere-packages-image-tooling-presubmit" ||
+						jobConfig.JobName == "emissary-tooling-presubmit" ||
+						jobConfig.JobName == "hello-eks-anywhere-tooling-presubmit" ||
+						jobConfig.JobName == "metallb-tooling-presubmit" ||
+						jobConfig.JobName == "metrics-server-presubmit" ||
+						jobConfig.JobName == "redis-tooling-presubmit" ||
+						jobConfig.JobName == "rolesanywhere-credential-helper-presubmit" ||
+						jobConfig.JobName == "trivy-tooling-presubmit" {
+						envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"})
+					} else {
+						envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"})
+					}
 				}
 
 				cluster, bucket, serviceAccountName := clusterDetails(jobType, jobConfig.Cluster, jobConfig.Bucket, jobConfig.ServiceAccountName)

--- a/templater/main.go
+++ b/templater/main.go
@@ -74,20 +74,7 @@ func main() {
 				}
 
 				if jobConfig.ImageBuild {
-					if strings.Contains(jobConfig.JobName, "autoscaler") ||
-						strings.Contains(jobConfig.JobName, "cloud-provider-aws") ||
-						strings.Contains(jobConfig.JobName, "harbor") ||
-						strings.Contains(jobConfig.JobName, "prometheus") ||
-						jobConfig.JobName == "aws-otel-collector-tooling-presubmit" ||
-						jobConfig.JobName == "distribution-tooling-presubmit" ||
-						jobConfig.JobName == "eks-anywhere-packages-image-tooling-presubmit" ||
-						jobConfig.JobName == "emissary-tooling-presubmit" ||
-						jobConfig.JobName == "hello-eks-anywhere-tooling-presubmit" ||
-						jobConfig.JobName == "metallb-tooling-presubmit" ||
-						jobConfig.JobName == "metrics-server-presubmit" ||
-						jobConfig.JobName == "redis-tooling-presubmit" ||
-						jobConfig.JobName == "rolesanywhere-credential-helper-presubmit" ||
-						jobConfig.JobName == "trivy-tooling-presubmit" {
+					if jobs.IsCuratedPackagesPresubmit(jobConfig.JobName) {
 						envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "067575901363.dkr.ecr.us-west-2.amazonaws.com"})
 					} else {
 						envVars = append(envVars, &types.EnvVar{Name: "ADDITIONAL_IMAGE_CACHE_REPOS", Value: "857151390494.dkr.ecr.us-west-2.amazonaws.com"})

--- a/templater/main.go
+++ b/templater/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -127,21 +126,21 @@ func main() {
 func GenerateProwjob(prowjobFileName, templateContent string, data map[string]interface{}) error {
 	bytes, err := utils.ExecuteTemplate(templateContent, data)
 	if err != nil {
-		return fmt.Errorf("error executing template: %v", err)
+		return fmt.Errorf("executing template: %v", err)
 	}
 
 	jobsFolderPath, err := getJobsFolderPath()
 	if err != nil {
-		return fmt.Errorf("error getting jobs folder path: %v", err)
+		return fmt.Errorf("getting jobs folder path: %v", err)
 	}
 
 	prowjobPath := filepath.Join(jobsFolderPath, data["repoName"].(string), prowjobFileName)
 	if err = os.MkdirAll(filepath.Dir(prowjobPath), 0o755); err != nil {
-		return fmt.Errorf("error creating Prowjob directory: %v", err)
+		return fmt.Errorf("creating Prowjob directory: %v", err)
 	}
 
-	if err = ioutil.WriteFile(prowjobPath, bytes, 0o644); err != nil {
-		return fmt.Errorf("error writing to path %s: %v", prowjobPath, err)
+	if err = os.WriteFile(prowjobPath, bytes, 0o644); err != nil {
+		return fmt.Errorf("writing to path %s: %v", prowjobPath, err)
 	}
 
 	return nil
@@ -150,7 +149,7 @@ func GenerateProwjob(prowjobFileName, templateContent string, data map[string]in
 func getJobsFolderPath() (string, error) {
 	gitRootOutput, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
-		return "", fmt.Errorf("error running the git command: %v", err)
+		return "", fmt.Errorf("running the git command: %v", err)
 	}
 	gitRoot := strings.Fields(string(gitRootOutput))[0]
 
@@ -166,7 +165,7 @@ func useTemplate(jobType string) (string, error) {
 	case "presubmit":
 		return presubmitTemplate, nil
 	default:
-		return "", fmt.Errorf("Unsupported job type: %s", jobType)
+		return "", fmt.Errorf("unsupported job type: %s", jobType)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
[#2389](https://github.com/aws/eks-anywhere-internal/issues/2389)

*Description of changes:*
**Commit 1:**
This commit updates the artifacts bucket for the packages prow jobs from the `857151390494` build account to `067575901363` regional packages beta account as we now build all packages and their dependencies in the regional pipeline. All the infra for non-regional packages were removed in CR-153632281 from the build account and the packages registries were updated in [#8538](https://github.com/aws/eks-anywhere/pull/8538) and [#8579](https://github.com/aws/eks-anywhere/pull/8579) from `857151390494` to `067575901363`.

**Commit 2:**
This commit updates the additional image cache repos for the packages prow jobs from the `857151390494` private ECR to `067575901363` private ECR.

*Testing:*
```
make build
make -C template prowjobs
make -C template verify-prowjobs
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
