### PR TITLE
Fix artifacts bucket env value in job constants

### DIFF
--- a/scripts/lint_prowjobs/main.go
+++ b/scripts/lint_prowjobs/main.go
@@ -83,10 +83,12 @@ func EnvVarsCheck(jc *JobConstants) presubmitCheck {
 			for _, env := range container.Env {
 				if index, exists := jc.envVarExist(env.Name); exists {
 					// check deepequal in case we decide to support EnvVarSource values in the future
-					if jobs.IsCuratedPackagesPresubmit(presubmitConfig.JobBase.Name) {
-						jc.EnvVars[index].Value = "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
+					jcEnvVar := jc.EnvVars[index]
+					// update the artifacts bucket env value if it is a curated packages presubmit job
+					if env.Name == "ARTIFACTS_BUCKET" && jobs.IsCuratedPackagesPresubmit(presubmitConfig.JobBase.Name) {
+						jcEnvVar.Value = "s3://codebuildprojectstack-be-pipelineoutputartifactsb-jvwhrzx05xwq"
 					}
-					if env != jc.EnvVars[index] {
+					if env != jcEnvVar {
 						lineToFind := fmt.Sprintf("name: %s", env.Name)
 						correctiveAction := fmt.Sprintf("Incorrect env var declared for %s in the %s container, update it to %s", env.Name, container.Name, env)
 						return false, findLineNumber(fileContentsString, lineToFind), correctiveAction


### PR DESCRIPTION
*Description of changes:*
This PR fixes the artifacts bucket env value in job-constants.yaml. If a PR updates the packages job followed by a non-packages job in alphabetical order of filepath, the bucket check on the packages job will happen first which will change the job constants to be the packages bucket and this change would be persistent with the current code so the bucket check on the non-packages job will fail since it will be against the packages bucket 

For example, when updating harbor and rufio jobs in the same commit and running the bucket check, it throws the following error:
```
rufio-presubmits.yaml:
61      Incorrect env var declared for ARTIFACTS_BUCKET in the build-container container, update it to {ARTIFACTS_BUCKET s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f nil}
❌ Validations failed!
```

This PR fixes the above issue by updating the logic in the `EnvVarsCheck` function to not update the job constants in a persistent manner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
