### PR TITLE
Migrate harbor-scanner-trivy prowjobs from aquasecurity to goharbor

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
   aws/eks-anywhere-build-tooling:
   - name: harbor-scanner-trivy-tooling-presubmit
     always_run: false
-    run_if_changed: "^build/lib/.*|Common.mk|projects/aquasecurity/harbor-scanner-trivy/.*"
+    run_if_changed: "^build/lib/.*|Common.mk|projects/goharbor/harbor-scanner-trivy/.*"
     branches:
     - ^main$
     cluster: "prow-presubmits-cluster"
@@ -54,7 +54,7 @@ presubmits:
           if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
         env:
         - name: PROJECT_PATH
-          value: "projects/aquasecurity/harbor-scanner-trivy"
+          value: "projects/goharbor/harbor-scanner-trivy"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -1,10 +1,10 @@
 jobName: harbor-scanner-trivy-tooling-presubmit
-runIfChanged: ^build/lib/.*|Common.mk|projects/aquasecurity/harbor-scanner-trivy/.*
+runIfChanged: ^build/lib/.*|Common.mk|projects/goharbor/harbor-scanner-trivy/.*
 branches:
 - ^main$
 commands:
 - if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
-projectPath: projects/aquasecurity/harbor-scanner-trivy
+projectPath: projects/goharbor/harbor-scanner-trivy
 imageBuild: true
 resources:
   requests:

--- a/templater/jobs/utils.go
+++ b/templater/jobs/utils.go
@@ -188,17 +188,17 @@ func GenerateJobConfig(data interface{}, filePath string) (types.JobConfig, erro
 
 func IsCuratedPackagesPresubmit(config string) bool {
 	return strings.Contains(config, "autoscaler") ||
-			strings.Contains(config, "cloud-provider-aws") ||
-			strings.Contains(config, "harbor") ||
-			strings.Contains(config, "prometheus") ||
-			config == "aws-otel-collector-tooling-presubmit" ||
-			config == "distribution-tooling-presubmit" ||
-			config == "eks-anywhere-packages-image-tooling-presubmit" ||
-			config == "emissary-tooling-presubmit" ||
-			config == "hello-eks-anywhere-tooling-presubmit" ||
-			config == "metallb-tooling-presubmit" ||
-			config == "metrics-server-presubmit" ||
-			config == "redis-tooling-presubmit" ||
-			config == "rolesanywhere-credential-helper-presubmit" ||
-			config == "trivy-tooling-presubmit"
+		strings.Contains(config, "cloud-provider-aws") ||
+		strings.Contains(config, "harbor") ||
+		strings.Contains(config, "prometheus") ||
+		config == "aws-otel-collector-tooling-presubmit" ||
+		config == "distribution-tooling-presubmit" ||
+		config == "eks-anywhere-packages-image-tooling-presubmit" ||
+		config == "emissary-tooling-presubmit" ||
+		config == "hello-eks-anywhere-tooling-presubmit" ||
+		config == "metallb-tooling-presubmit" ||
+		config == "metrics-server-presubmit" ||
+		config == "redis-tooling-presubmit" ||
+		config == "rolesanywhere-credential-helper-presubmit" ||
+		config == "trivy-tooling-presubmit"
 }


### PR DESCRIPTION
*Issue #, if available:*
[#4017](https://github.com/aws/eks-anywhere-build-tooling/issues/4017)

*Description of changes:*
This PR migrates the harbor-scanner-trivy project presubmit jobs from aquasecurity to goharbor.

*Testing:*
```
make -C templater prowjobs
make -C templater verify-prowjobs
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
