### PR TITLE
Use moby/buildkit image from private ECR

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-27-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-28-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-29-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-30-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/autoscaler-1-31-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-image-builder-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/aws-otel-collector-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/boots-presubmit.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/bottlerocket-bootstrap-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             cpu: "8"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cert-manager-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
             cpu: "8"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-27-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-28-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-29-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-30-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-aws-1-31-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-nutanix-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-27-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-28-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-29-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-30-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloud-provider-vsphere-1-31-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cloudstack-cloudmonkey-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-aws-snow-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-cloudstack-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-tinkerbell-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-vsphere-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-amd64.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/containerd-presubmits-arm64.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cri-tools-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/distribution-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-admin-image-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-a-upgrader-image-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
             cpu: "1024m"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.21.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics-release-0.21.yaml
@@ -70,7 +70,7 @@ periodics:
         mountPath: /secrets/github-secrets
         readOnly: true
     - name: buildkitd
-      image: moby/buildkit:v0.12.5-rootless
+      image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-attribution-periodics.yaml
@@ -68,7 +68,7 @@ periodics:
         mountPath: /secrets/github-secrets
         readOnly: true
     - name: buildkitd
-      image: moby/buildkit:v0.12.5-rootless
+      image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
       command:
       - sh
       args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-cli-tools-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-diagnostic-collector-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/eks-anywhere-packages-image-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/emissary-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/envoy-presubmit.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-bootstrap-provider-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-controller-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/etcdadm-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/flux-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/govmomi-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "4Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-scanner-trivy-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hegel-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hello-eks-anywhere-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-controller-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/helm-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
@@ -81,7 +81,7 @@ presubmits:
             cpu: "8"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-arm64.yaml
@@ -82,7 +82,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hub-presubmit.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-27-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-rbac-proxy-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kube-vip-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kustomize-controller-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-amd64.yaml
@@ -74,7 +74,7 @@ presubmits:
             cpu: "4"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/linuxkit-presubmits-arm64.yaml
@@ -76,7 +76,7 @@ presubmits:
             cpu: "4"
             ephemeral-storage: "50Gi"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/local-path-provisioner-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metallb-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/metrics-server-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/notification-controller-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-node-exporter-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/redis-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rolesanywhere-credential-helper-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/rufio-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-amd64.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/runc-presubmits-arm64.yaml
@@ -71,7 +71,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/source-controller-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tink-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-chart-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-crds-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/tinkerbell-stack-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
             memory: "16Gi"
             cpu: "8"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/troubleshoot-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-cluster-controller-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
             memory: "8Gi"
             cpu: "1024m"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
+++ b/jobs/aws/eks-anywhere/eks-anywhere-e2e-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
             memory: "16Gi"
             cpu: "4"
       - name: buildkitd
-        image: moby/buildkit:v0.12.5-rootless
+        image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.12.5-rootless
         command:
         - sh
         args:

--- a/templater/main.go
+++ b/templater/main.go
@@ -14,6 +14,11 @@ import (
 	"github.com/aws/eks-anywhere-prow-jobs/templater/jobs"
 )
 
+const (
+	buildkitImageRepo = "857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit"
+	buildkitImageTag  = "v0.12.5-rootless"
+)
+
 var (
 	jobsFolder    = "jobs"
 	orgsSupported = []string{"aws"}
@@ -35,8 +40,6 @@ var editWarning string
 //go:generate cp ../BUILDER_BASE_TAG_FILE ./BUILDER_BASE_TAG_FILE
 //go:embed BUILDER_BASE_TAG_FILE
 var builderBaseTag string
-
-var buildkitImageTag = "v0.12.5-rootless"
 
 func main() {
 	jobsFolderPath, err := getJobsFolderPath()
@@ -69,7 +72,7 @@ func main() {
 				envVars := jobConfig.EnvVars
 
 				if jobConfig.UseDockerBuildX {
-					envVars = append(envVars, &types.EnvVar{Name: "BUILDKITD_IMAGE", Value: "moby/buildkit:" + buildkitImageTag})
+					envVars = append(envVars, &types.EnvVar{Name: "BUILDKITD_IMAGE", Value: fmt.Sprintf("%s:%s", buildkitImageRepo, buildkitImageTag)})
 					envVars = append(envVars, &types.EnvVar{Name: "USE_BUILDX", Value: "true"})
 				}
 
@@ -102,6 +105,7 @@ func main() {
 					"serviceAccountName":           serviceAccountName,
 					"command":                      strings.Join(jobConfig.Commands, "\n&&\n"),
 					"builderBaseTag":               builderBaseTag,
+					"buildkitImageRepo":            buildkitImageRepo,
 					"buildkitImageTag":             buildkitImageTag,
 					"resources":                    jobConfig.Resources,
 					"envVars":                      envVars,

--- a/templater/templates/periodics.yaml
+++ b/templater/templates/periodics.yaml
@@ -112,7 +112,7 @@ periodics:
       {{- end }}
     {{- if .imageBuild }}
     - name: buildkitd
-      image: moby/buildkit:{{ .buildkitImageTag }}
+      image: {{ .buildkitImageRepo }}:{{ .buildkitImageTag }}
       command:
       - sh
       args:

--- a/templater/templates/postsubmits.yaml
+++ b/templater/templates/postsubmits.yaml
@@ -126,7 +126,7 @@ postsubmits:
         {{- end }}
       {{- if .imageBuild }}
       - name: buildkitd
-        image: moby/buildkit:{{ .buildkitImageTag }}
+        image: {{ .buildkitImageRepo }}:{{ .buildkitImageTag }}
         command:
         - sh
         args:

--- a/templater/templates/presubmits.yaml
+++ b/templater/templates/presubmits.yaml
@@ -139,7 +139,7 @@ presubmits:
         {{- end }}
       {{- if .imageBuild }}
       - name: buildkitd
-        image: moby/buildkit:{{ .buildkitImageTag }}
+        image: {{ .buildkitImageRepo }}:{{ .buildkitImageTag }}
         command:
         - sh
         args:


### PR DESCRIPTION
Using `moby/buildkit` image from private ECR to avoid being rate-limited by DockerHub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
