### PR TITLE
add disk space for harbor presubmit

### DIFF
--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -17,3 +17,4 @@ resources:
   requests:
     memory: 16Gi
     cpu: 8
+    ephemeral-storage: 50Gi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add disk space for harbor presubmit job
- The presubmit is failing because lack of disk space: https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-anywhere-build-tooling/4590/harbor-tooling-presubmit/1920699029411336192#2:build-container-build-log.txt%3A1070
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
