### PR TITLE
Add ephemeral storage for kind presubmit job to fix no disk space left

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/harbor-presubmits.yaml
@@ -72,6 +72,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "8"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-28-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-29-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-30-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-31-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-32-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-32-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/jobs/aws/eks-anywhere-build-tooling/kind-1-33-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/kind-1-33-presubmits.yaml
@@ -68,6 +68,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "4"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/kind-1-X-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/kind-1-X-presubmits.yaml
@@ -13,3 +13,4 @@ resources:
   requests:
     memory: 16Gi
     cpu: 4
+    ephemeral-storage: 50Gi


### PR DESCRIPTION

*Issue #, if available:*
pre-submit job for kind is failing with no disk space left. In this PR, I am adding ephemeral storage for kind pre-submit job

error job - https://prow.eks.amazonaws.com/log?container=build-container&id=1928957189225975808&job=kind-1-28-tooling-presubmit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
