### PR TITLE
Add ephermeral storage for trivy-presubmits

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -66,6 +66,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "8"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/trivy-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/trivy-presubmits.yaml
@@ -10,4 +10,5 @@ resources:
   requests:
     memory: 16Gi
     cpu: 8
+    ephemeral-storage: 50Gi
 


### PR DESCRIPTION
*Description of changes:*

Trivy presubmits is failing because of "copy_file_range: no space left on device"

Added 50Gi to the job should fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
