### PR TITLE
Add ephemeral storage for prometheus/prometheus presubmits

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -66,6 +66,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "8"
+            ephemeral-storage: "50Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/prometheus-prometheus-presubmits.yaml
@@ -10,4 +10,4 @@ resources:
   requests:
     memory: 16Gi
     cpu: 8
-
+    ephemeral-storage: 50Gi


### PR DESCRIPTION
*Description of changes:*
[prometheus-prometheus-tooling-presubmit](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-anywhere-build-tooling/4812/prometheus-prometheus-tooling-presubmit/1965477325025841152) job is failing with error 
```
error: failed to solve: ResourceExhausted: failed to mkdir /home/user/.local/share/buildkit/runc-native/snapshots/snapshots/23/usr/share/prometheus: mkdir /usr/share/prometheus: no space left on device
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
