### PR TITLE
Add more space for hook presubmit

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
@@ -79,7 +79,7 @@ presubmits:
           requests:
             memory: "16Gi"
             cpu: "8"
-            ephemeral-storage: "50Gi"
+            ephemeral-storage: "60Gi"
       - name: buildkitd
         image: 857151390494.dkr.ecr.us-west-2.amazonaws.com/moby/buildkit:v0.18.2-rootless
         command:

--- a/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
+++ b/templater/jobs/presubmit/eks-anywhere-build-tooling/hook-presubmit-amd64.yaml
@@ -22,4 +22,4 @@ resources:
   requests:
     memory: 16Gi
     cpu: 8
-    ephemeral-storage: 50Gi
+    ephemeral-storage: 60Gi


### PR DESCRIPTION
*Issue #, if available:*
hook-presbumit-amd64 is faling with no space issue
```
failed to solve: ResourceExhausted: failed to prepare cdyq4c7njpssq36oopehdqsb5 as 77txfidg7dxhvm7n4tfbgrjdl: copying of parent failed: failed to mkdir /home/user/.local/share/buildkit/runc-native/snapshots/snapshots/new-1526849254/usr/share/augeas: mkdir /home/user/.local/share/buildkit/runc-native/snapshots/snapshots/new-1526849254/usr/share/augeas: no space left on device
```

https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-anywhere-build-tooling/4851/hook-tooling-presubmit-amd64/1969275969596297216


*Description of changes:*
Increasing ephemeral space from 50GB to 60GB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
